### PR TITLE
Enable TCP_NODELAY and fix partial-write handling (v0.2.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grubbnet"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Declan Hopkins <hopkins.declan@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,6 +26,7 @@ pub struct Client {
     buffer: NetworkBuffer,
     incoming_packets: VecDeque<Packet>,
     outgoing_packets: VecDeque<Box<dyn PacketBody>>,
+    outgoing_buffer: Vec<u8>,
     is_disconnected: bool,
 }
 
@@ -33,6 +34,10 @@ impl Client {
     pub fn connect(ip: &str, port: u16) -> Result<Client> {
         let address = format!("{}:{}", ip, port).parse().unwrap();
         let mut tcp_stream = TcpStream::connect(address)?;
+
+        // Disable Nagle's algorithm so small, latency-sensitive packets are sent
+        // immediately instead of being buffered by the OS.
+        tcp_stream.set_nodelay(true)?;
 
         // Register for reading/writing
         let poll = Poll::new().unwrap();
@@ -49,6 +54,7 @@ impl Client {
             buffer: NetworkBuffer::new(),
             incoming_packets: VecDeque::new(),
             outgoing_packets: VecDeque::new(),
+            outgoing_buffer: Vec::new(),
             is_disconnected: false,
         })
     }
@@ -138,6 +144,8 @@ impl Client {
 
                     // Handle writing
                     if event.is_writable() {
+                        // Serialize any newly queued packets onto the end of the outgoing
+                        // byte buffer, preserving send order.
                         while let Some(packet) = self.outgoing_packets.pop_front() {
                             let data = match serialize_packet(packet) {
                                 Ok(d) => d,
@@ -147,16 +155,23 @@ impl Client {
                                 }
                             };
 
-                            match send_bytes(&mut self.tcp_stream, &data) {
+                            self.outgoing_buffer.extend_from_slice(&data);
+                            net_events.push(ClientEvent::SentPacket(data.len()));
+                        }
+
+                        // Flush as much of the outgoing buffer as the socket will accept.
+                        // Any bytes left unsent (partial write or WouldBlock) are kept and
+                        // retried on the next writable event.
+                        if !self.outgoing_buffer.is_empty() {
+                            match send_bytes(&mut self.tcp_stream, &self.outgoing_buffer) {
                                 Ok(sent_bytes) => {
-                                    net_events.push(ClientEvent::SentPacket(sent_bytes));
+                                    self.outgoing_buffer.drain(..sent_bytes);
                                 }
                                 Err(e) => {
                                     net_events.push(ClientEvent::Disconnected);
 
                                     eprintln!("Unexpected error when sending bytes! {}", e);
                                     self.is_disconnected = true;
-                                    break;
                                 }
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,24 +25,157 @@ pub enum PacketRecipient {
 }
 
 /// Send some bytes to a socket.
-/// Returns the number of bytes sent, or an `Error`.
+///
+/// Returns the number of bytes actually written. This may be fewer than
+/// `buffer.len()` if the socket's send buffer filled up (a `WouldBlock`
+/// condition on a nonblocking socket), in which case the caller is responsible
+/// for retrying the unsent remainder on the next writable event. Only returns
+/// an `Error` on a genuine I/O failure.
 pub fn send_bytes(socket: &mut TcpStream, buffer: &[u8]) -> Result<usize> {
-    let mut len = buffer.len();
-    if len == 0 {
+    write_bytes(socket, buffer)
+}
+
+/// Writes `buffer` to `socket`, advancing past partially written chunks.
+///
+/// Generic over `Write` so the partial-write and `WouldBlock` handling can be
+/// unit tested without a real socket.
+fn write_bytes<W: Write>(socket: &mut W, buffer: &[u8]) -> Result<usize> {
+    if buffer.is_empty() {
         return Err(Error::InvalidData);
     }
 
-    // Keep sending until we've sent the entire buffer
-    while len > 0 {
-        match socket.write(buffer) {
-            Ok(sent_bytes) => {
-                len -= sent_bytes;
+    let mut total_sent: usize = 0;
+    while total_sent < buffer.len() {
+        match socket.write(&buffer[total_sent..]) {
+            Ok(0) => {
+                // The socket isn't able to accept any more bytes right now.
+                break;
             }
-            Err(_) => {
-                return Err(Error::FailedToSendBytes);
+            Ok(sent_bytes) => {
+                total_sent += sent_bytes;
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                // The send buffer is full. Stop here and let the caller retry
+                // the remaining bytes once the socket is writable again.
+                break;
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                // Interrupted before any bytes were written, so just retry.
+                continue;
+            }
+            Err(e) => {
+                return Err(e.into());
             }
         }
     }
 
-    Ok(buffer.len())
+    Ok(total_sent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::io::{self, ErrorKind, Write};
+
+    /// A `Write` implementation that returns a scripted sequence of results,
+    /// recording everything it accepts so tests can assert on byte ordering.
+    struct MockWriter {
+        results: VecDeque<io::Result<usize>>,
+        written: Vec<u8>,
+    }
+
+    impl MockWriter {
+        fn new(results: Vec<io::Result<usize>>) -> Self {
+            MockWriter {
+                results: results.into_iter().collect(),
+                written: Vec::new(),
+            }
+        }
+    }
+
+    impl Write for MockWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            match self.results.pop_front() {
+                Some(Ok(n)) => {
+                    let n = n.min(buf.len());
+                    self.written.extend_from_slice(&buf[..n]);
+                    Ok(n)
+                }
+                Some(Err(e)) => Err(e),
+                // Default once the script is exhausted: accept everything.
+                None => {
+                    self.written.extend_from_slice(buf);
+                    Ok(buf.len())
+                }
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn empty_buffer_is_invalid() {
+        let mut w = MockWriter::new(vec![]);
+        assert!(matches!(write_bytes(&mut w, &[]), Err(Error::InvalidData)));
+    }
+
+    #[test]
+    fn full_write_in_one_call() {
+        let mut w = MockWriter::new(vec![Ok(5)]);
+        let sent = write_bytes(&mut w, b"hello").unwrap();
+        assert_eq!(sent, 5);
+        assert_eq!(w.written, b"hello");
+    }
+
+    #[test]
+    fn partial_writes_advance_the_slice() {
+        // Two partial writes should not re-send already sent bytes.
+        let mut w = MockWriter::new(vec![Ok(2), Ok(3)]);
+        let sent = write_bytes(&mut w, b"hello").unwrap();
+        assert_eq!(sent, 5);
+        assert_eq!(w.written, b"hello");
+    }
+
+    #[test]
+    fn would_block_stops_without_error_and_preserves_remainder() {
+        // Send 2 bytes, then the socket would block.
+        let mut w = MockWriter::new(vec![Ok(2), Err(io::Error::from(ErrorKind::WouldBlock))]);
+        let sent = write_bytes(&mut w, b"hello").unwrap();
+        assert_eq!(sent, 2);
+        assert_eq!(w.written, b"he");
+
+        // The caller retries the remainder on the next writable event.
+        let mut w2 = MockWriter::new(vec![Ok(3)]);
+        let sent2 = write_bytes(&mut w2, b"llo").unwrap();
+        assert_eq!(sent2, 3);
+        assert_eq!(w2.written, b"llo");
+    }
+
+    #[test]
+    fn would_block_immediately_sends_nothing() {
+        let mut w = MockWriter::new(vec![Err(io::Error::from(ErrorKind::WouldBlock))]);
+        let sent = write_bytes(&mut w, b"hello").unwrap();
+        assert_eq!(sent, 0);
+        assert!(w.written.is_empty());
+    }
+
+    #[test]
+    fn interrupted_is_retried() {
+        let mut w = MockWriter::new(vec![Err(io::Error::from(ErrorKind::Interrupted)), Ok(5)]);
+        let sent = write_bytes(&mut w, b"hello").unwrap();
+        assert_eq!(sent, 5);
+        assert_eq!(w.written, b"hello");
+    }
+
+    #[test]
+    fn real_error_is_returned() {
+        let mut w = MockWriter::new(vec![Err(io::Error::from(ErrorKind::ConnectionReset))]);
+        match write_bytes(&mut w, b"hello") {
+            Err(Error::Io(e)) => assert_eq!(e.kind(), ErrorKind::ConnectionReset),
+            other => panic!("expected Io error, got {:?}", other),
+        }
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,6 +34,7 @@ pub struct Connection {
     is_disconnected: bool,
     buffer: NetworkBuffer,
     outgoing_packets: VecDeque<Box<dyn PacketBody>>,
+    outgoing_buffer: Vec<u8>,
 }
 
 impl Connection {
@@ -44,6 +45,7 @@ impl Connection {
             is_disconnected: false,
             buffer: NetworkBuffer::new(),
             outgoing_packets: VecDeque::new(),
+            outgoing_buffer: Vec::new(),
         }
     }
 }
@@ -189,6 +191,15 @@ impl Server {
                         continue;
                     }
 
+                    // Disable Nagle's algorithm so small, latency-sensitive packets are
+                    // sent immediately instead of being buffered by the OS.
+                    if let Err(e) = socket.set_nodelay(true) {
+                        eprintln!(
+                            "Failed to set TCP_NODELAY on connection from {}! {}",
+                            addr, e
+                        );
+                    }
+
                     // Increment our token counter, then create a new token for this connection
                     self.token_counter += 1;
                     let token = Token(self.token_counter);
@@ -268,6 +279,8 @@ impl Server {
 
                     // Handle writing
                     if event.is_writable() {
+                        // Serialize any newly queued packets onto the end of the outgoing
+                        // byte buffer, preserving send order.
                         while let Some(packet) = conn.outgoing_packets.pop_front() {
                             let data = match serialize_packet(packet) {
                                 Ok(d) => d,
@@ -277,9 +290,17 @@ impl Server {
                                 }
                             };
 
-                            match send_bytes(&mut conn.socket, &data) {
+                            conn.outgoing_buffer.extend_from_slice(&data);
+                            net_events.push(ServerEvent::SentPacket(token, data.len()));
+                        }
+
+                        // Flush as much of the outgoing buffer as the socket will accept.
+                        // Any bytes left unsent (partial write or WouldBlock) are kept and
+                        // retried on the next writable event.
+                        if !conn.outgoing_buffer.is_empty() {
+                            match send_bytes(&mut conn.socket, &conn.outgoing_buffer) {
                                 Ok(sent_bytes) => {
-                                    net_events.push(ServerEvent::SentPacket(token, sent_bytes));
+                                    conn.outgoing_buffer.drain(..sent_bytes);
                                 }
                                 Err(e) => {
                                     eprintln!(
@@ -287,7 +308,6 @@ impl Server {
                                         conn.token.0, e
                                     );
                                     conn.is_disconnected = true;
-                                    break;
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

Players reported intermittent lag spikes in a TCP-based game built on grubbnet. Investigation found two root causes in the socket setup and write path.

### 1. Nagle's algorithm was never disabled
grubbnet had no set_nodelay/TCP_NODELAY calls anywhere, so Nagle's algorithm was on for every client and accepted server socket. For a game that sends many small, latency-sensitive packets (movement, chat, entity state, interaction), this batches writes and adds latency (classic Nagle + delayed-ACK stalls).

- `Client::connect` now calls `set_nodelay(true)` right after `TcpStream::connect`.
- The server calls `set_nodelay(true)` right after `accept()` (logs on failure rather than dropping the accept).

mio 0.8's `TcpStream` exposes `set_nodelay` directly, so no conversion to a std socket is needed.

### 2. `send_bytes` mishandled partial writes and `WouldBlock`
The old loop re-sent the entire buffer on every iteration (duplicate bytes on the wire and a `usize` underflow on any partial write) and treated `WouldBlock` as a fatal error, which disconnected clients on transient nonblocking backpressure and dropped the in-flight packet.

- `send_bytes` now advances past partially written chunks, treats `WouldBlock`/`Interrupted` as non-fatal, and only errors on a genuine I/O failure. The logic is extracted into a generic `write_bytes<W: Write>` so it can be unit tested.
- `Connection` and `Client` gained an `outgoing_buffer` that retains unsent bytes and retries them on the next writable event. Clients now disconnect only on real I/O errors.

### Tests
Added 7 unit tests covering full write, partial writes, `WouldBlock` (immediate and after a partial write), `Interrupted` retry, real I/O error, and empty buffer.

`cargo test` passes (7/7). `cargo build --lib` and `cargo check --features crypto` compile cleanly.

Version bumped to `0.2.1`.
