### PR TITLE
[?] Remove bincode dependency and migrate examples to wincode (v0.2.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grubbnet"
-version = "0.2.1"
-authors = ["Declan Hopkins <hopkins.declan@gmail.com>"]
+version = "0.2.2"
+authors = ["Declan Hopkins <ratwizarddev@gmail.com>"]
 edition = "2018"
 license = "MIT"
 readme = "README.md"
@@ -17,10 +17,11 @@ crate-type = ["rlib"]
 mio = { version = "0.8", features = ["os-poll", "net"] }
 byteorder = "1.5.0"
 derive_more = "0.99.17"
-serde = { version = "1.0.228", features = ["derive"] }
-bincode = "1.1.3"
 openssl = { version = "0.10.75", optional = true }
 bcrypt = { version = "0.19", optional = true }
+
+[dev-dependencies]
+wincode = { version = "0.5.5", features = ["derive"] }
 
 [features]
 crypto = ["openssl", "bcrypt"]

--- a/examples/simple_client.rs
+++ b/examples/simple_client.rs
@@ -2,7 +2,7 @@ use grubbnet::{packet::PacketBody, Client, ClientEvent, Result};
 
 /// 0x00 - Ping Packet
 /// Client
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(wincode::SchemaWrite, wincode::SchemaRead, Clone)]
 pub struct PingPacket {
     pub msg: String,
 }
@@ -13,10 +13,7 @@ impl PacketBody for PingPacket {
     }
 
     fn serialize(&self) -> Result<Vec<u8>> {
-        match bincode::config().big_endian().serialize::<Self>(&self) {
-            Ok(d) => Ok(d),
-            Err(_e) => Err(grubbnet::Error::InvalidData),
-        }
+        wincode::serialize(self).map_err(|_e| grubbnet::Error::InvalidData)
     }
 
     fn deserialize(_data: &[u8]) -> Result<Self> {
@@ -30,7 +27,7 @@ impl PacketBody for PingPacket {
 
 /// 0x00 - Pong Packet
 /// Server
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(wincode::SchemaWrite, wincode::SchemaRead, Clone)]
 pub struct PongPacket {
     pub msg: String,
 }
@@ -45,10 +42,7 @@ impl PacketBody for PongPacket {
     }
 
     fn deserialize(data: &[u8]) -> Result<Self> {
-        match bincode::config().big_endian().deserialize::<Self>(data) {
-            Ok(p) => Ok(p),
-            Err(_e) => Err(grubbnet::Error::InvalidData),
-        }
+        wincode::deserialize(data).map_err(|_e| grubbnet::Error::InvalidData)
     }
 
     fn id(&self) -> u8 {

--- a/examples/simple_server.rs
+++ b/examples/simple_server.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 /// 0x00 - Ping Packet
 /// Client
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(wincode::SchemaWrite, wincode::SchemaRead, Clone)]
 pub struct PingPacket {
     pub msg: String,
 }
@@ -18,10 +18,7 @@ impl PacketBody for PingPacket {
     }
 
     fn deserialize(data: &[u8]) -> Result<Self> {
-        match bincode::config().big_endian().deserialize::<Self>(data) {
-            Ok(p) => Ok(p),
-            Err(_e) => Err(grubbnet::Error::InvalidData),
-        }
+        wincode::deserialize(data).map_err(|_e| grubbnet::Error::InvalidData)
     }
 
     fn id(&self) -> u8 {
@@ -31,7 +28,7 @@ impl PacketBody for PingPacket {
 
 /// 0x00 - Pong Packet
 /// Server
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(wincode::SchemaWrite, wincode::SchemaRead, Clone)]
 pub struct PongPacket {
     pub msg: String,
 }
@@ -42,10 +39,7 @@ impl PacketBody for PongPacket {
     }
 
     fn serialize(&self) -> Result<Vec<u8>> {
-        match bincode::config().big_endian().serialize::<Self>(&self) {
-            Ok(d) => Ok(d),
-            Err(_e) => Err(grubbnet::Error::InvalidData),
-        }
+        wincode::serialize(self).map_err(|_e| grubbnet::Error::InvalidData)
     }
 
     fn deserialize(_data: &[u8]) -> Result<Self> {


### PR DESCRIPTION
## Summary

grubbnet's library code (`src/`) uses `byteorder` for packet framing and never references `bincode` or `serde`. Those two crates were declared as regular `[dependencies]` but were only used by the example client/server to serialize their demo packet bodies. As a result, every downstream consumer of grubbnet (notably antorum's `game-server`, `sqllib`, and `web-server`) inherited `bincode` transitively.

This PR:
- Migrates the two examples from `bincode` (+ `serde` derives) to `wincode`, the bincode-compatible successor.
- Removes `bincode` and the now-unused `serde` from `[dependencies]`.
- Adds `wincode` as a `[dev-dependency]` (only the examples need it).
- Bumps the crate to `0.2.2`.

## Verification

- `cargo build --examples` and `cargo test` pass (7 lib tests).
- `cargo tree -i bincode` and `cargo tree -i serde` both report no match: grubbnet no longer depends on either.
- Patching antorum's server workspace to this local grubbnet `0.2.2` removes `bincode` from the entire server tree (`cargo tree -i bincode` finds nothing across game-server, sqllib, and web-server).

## Downstream follow-up (antorum)

Once this is published as `0.2.2`, bump `game-server`'s `grubbnet` requirement to `0.2.2` to drop `bincode` from the antorum server workspace entirely. This pairs with the antorum game-server migration to wincode (issue #756).
