### PR TITLE
[fixes #9] Fix unbounded read offset and unsound NetworkBuffer::drain (v0.2.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grubbnet"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Declan Hopkins <ratwizarddev@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -20,11 +20,42 @@ Instead of dealing with raw bytes, Grubbnet operates based on packets that the d
 
 Packet headers are 3 bytes (2 bytes for a 16 bit body size, and 1 byte for an 8 bit packet id). In the future, I'd like to allow developers to also define their own header for more flexibility. The header allows Grubbnet to recognize when it's being sent a packet, what the packet type is, and how many bytes it needs to wait for before it has all the data required to reconstruct the packet. After this happens, the packet id and (still serialized) body are handed back to the developer through the incoming packet queue, and they can do as they please with it.
 
+### Limits and framing
+Incoming bytes are accumulated in a fixed 16 KiB buffer (`MAX_BUFFER_SIZE`) per connection until
+a complete packet can be pulled off the front of it. A packet body may be up to 8191 bytes
+(`MAX_PACKET_BODY_SIZE` is 8192, and the check is exclusive), so the buffer always has roughly
+twice the headroom of the largest legal packet.
+
+Packets are framed, not message-oriented, so none of this is affected by how a peer chooses to
+split its writes. A packet spread across several `write` calls is reassembled, and several
+packets delivered in a single `write` burst all arrive intact and in order, however the bytes
+happen to land in TCP segments.
+
+At most one bufferful is read per connection per readable event, so a peer sending a firehose of
+bytes cannot starve the other connections. Anything left over is picked up on the next tick.
+
+### Protocol violations
+Grubbnet drops a connection, rather than panicking or spinning, when a peer does something the
+protocol cannot recover from:
+
+* a header declaring a body larger than `MAX_PACKET_BODY_SIZE`, which can never be satisfied
+* a completely full buffer that still contains no complete packet, which can never make progress
+
+Both are reported through the ordinary `ServerEvent::ClientDisconnected` (or
+`ClientEvent::Disconnected`) path, so there is no new event variant to handle. A merely
+*incomplete* packet is not a violation: the connection is left alone until the rest arrives.
+
+`grubbnet::buffer::NetworkBuffer` exposes its `data` and `offset` fields publicly for
+convenience. `offset` is never trusted as a length: every method clamps it to `MAX_BUFFER_SIZE`
+before deriving an index from it, so no value of `offset` can cause an out-of-bounds access.
+Prefer `try_drain` over `drain` if you use the buffer directly; it reports an error instead of
+panicking.
+
 ## Usage
  Add this to your `Cargo.toml`:
  ```toml
  [dependencies]
- grubbnet = "0.1"
+ grubbnet = "0.2"
  ```
 
 Hosting a barebones server that sends a simple packet:

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,9 +1,18 @@
+use crate::error::{Error, Result};
+
 pub const MAX_BUFFER_SIZE: usize = 1024 * 16;
 
 // TODO (Declan, 10/12/2019)
 // We should probably be using a ring buffer instead.
 
 /// A simple byte buffer, useful for storing bytes that are going to be consumed in packets.
+///
+/// # Invariant
+///
+/// `offset` must never exceed [`MAX_BUFFER_SIZE`]. Because `data` and `offset` are public
+/// fields, that invariant cannot be enforced by construction, so every method that derives a
+/// length or an index from `offset` re-establishes it first (see [`NetworkBuffer::len`]).
+/// No method on this type can read or write out of bounds, whatever `offset` is set to.
 pub struct NetworkBuffer {
     pub data: [u8; MAX_BUFFER_SIZE],
     pub offset: usize,
@@ -17,24 +26,300 @@ impl NetworkBuffer {
         }
     }
 
-    /// Deletes `count` bytes from the front of the buffer, then shifts the rest of the buffer back in place at index 0.
-    pub fn drain(&mut self, count: usize) {
-        if count > self.offset {
-            panic!("Attempted to drain more bytes ({}) than present in buffer ({})", count, self.offset);
+    /// The number of bytes currently buffered.
+    ///
+    /// This is `offset` clamped to [`MAX_BUFFER_SIZE`]. Always prefer this over reading
+    /// `offset` directly: `offset` is a public field and may hold any value, so it must never
+    /// be used to derive a length or an index without being clamped first.
+    pub fn len(&self) -> usize {
+        self.offset.min(MAX_BUFFER_SIZE)
+    }
+
+    /// Returns true if there are no bytes buffered.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The number of bytes that can still be written into the buffer.
+    pub fn remaining(&self) -> usize {
+        MAX_BUFFER_SIZE - self.len()
+    }
+
+    /// Returns true if there is no room left to read more bytes into the buffer.
+    pub fn is_full(&self) -> bool {
+        self.remaining() == 0
+    }
+
+    /// The bytes currently buffered.
+    pub fn filled(&self) -> &[u8] {
+        let len = self.len();
+        &self.data[..len]
+    }
+
+    /// The unwritten portion of the buffer, ready to be read into.
+    ///
+    /// This is recomputed from the current [`NetworkBuffer::len`] on every call, so it must be
+    /// re-acquired after every write. Hoisting it out of a read loop is what caused the
+    /// unbounded-`offset` heap corruption fixed in 0.2.3.
+    pub fn writable(&mut self) -> &mut [u8] {
+        let len = self.len();
+        &mut self.data[len..]
+    }
+
+    /// Re-establishes the type invariant by clamping `offset` to [`MAX_BUFFER_SIZE`].
+    ///
+    /// `data` and `offset` are public fields, so any code - including entirely safe downstream
+    /// code - can put the buffer into a state this crate would never produce. Call this before
+    /// deriving any length or index from `offset`.
+    pub fn normalize(&mut self) {
+        self.offset = self.len();
+    }
+
+    /// Records that `count` bytes were written into the slice returned by
+    /// [`NetworkBuffer::writable`].
+    ///
+    /// The resulting offset is clamped to [`MAX_BUFFER_SIZE`], so even a misbehaving `Read`
+    /// implementation that reports more bytes than the destination slice could hold cannot
+    /// push the buffer past the end of its own backing array.
+    pub fn advance(&mut self, count: usize) {
+        self.offset = self.offset.saturating_add(count).min(MAX_BUFFER_SIZE);
+    }
+
+    /// Deletes `count` bytes from the front of the buffer, then shifts the rest of the buffer
+    /// back in place at index 0.
+    ///
+    /// Returns `Error::InvalidData` if `count` is greater than the number of buffered bytes,
+    /// rather than panicking. Prefer this over [`NetworkBuffer::drain`] anywhere `count` is
+    /// derived from network input: a panic in a single-process server is still a remote kill.
+    pub fn try_drain(&mut self, count: usize) -> Result<()> {
+        // `offset` is public, so re-establish the type invariant before deriving any length
+        // from it. Everything below this line works off `len`, never off `self.offset`.
+        self.normalize();
+        let len = self.len();
+
+        if count > len {
+            return Err(Error::InvalidData);
         }
-        unsafe {
-            use std::ptr;
-            ptr::copy(
-                self.data.as_ptr().add(count),
-                self.data.as_mut_ptr(),
-                self.offset - count,
+
+        // Bounds-checked equivalent of the `ptr::copy` this used to do inside an `unsafe`
+        // block. `count <= len <= MAX_BUFFER_SIZE`, so the source range is always valid.
+        self.data.copy_within(count..len, 0);
+        self.offset = len - count;
+
+        Ok(())
+    }
+
+    /// Deletes `count` bytes from the front of the buffer, then shifts the rest of the buffer back in place at index 0.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `count` is greater than the number of buffered bytes. Kept for API
+    /// compatibility; [`NetworkBuffer::try_drain`] is the preferred form, and is what this
+    /// crate uses internally so that malformed input cannot take the process down.
+    pub fn drain(&mut self, count: usize) {
+        let len = self.len();
+        if self.try_drain(count).is_err() {
+            panic!(
+                "Attempted to drain more bytes ({}) than present in buffer ({})",
+                count, len
             );
         }
-        self.offset -= count;
     }
 
     pub fn clear(&mut self) {
         self.data = [0; MAX_BUFFER_SIZE];
         self.offset = 0;
+    }
+}
+
+impl Default for NetworkBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a buffer holding `bytes`, with a correct offset.
+    fn buffer_with(bytes: &[u8]) -> NetworkBuffer {
+        let mut buffer = NetworkBuffer::new();
+        buffer.data[..bytes.len()].copy_from_slice(bytes);
+        buffer.offset = bytes.len();
+        buffer
+    }
+
+    #[test]
+    fn drain_zero_is_a_no_op() {
+        let mut buffer = buffer_with(&[1, 2, 3, 4]);
+
+        buffer.drain(0);
+
+        assert_eq!(buffer.offset, 4);
+        assert_eq!(buffer.filled(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn drain_some_shifts_the_remainder_to_the_front() {
+        let mut buffer = buffer_with(&[1, 2, 3, 4, 5]);
+
+        buffer.drain(2);
+
+        assert_eq!(buffer.offset, 3);
+        assert_eq!(buffer.filled(), &[3, 4, 5]);
+    }
+
+    #[test]
+    fn drain_everything_empties_the_buffer() {
+        let mut buffer = buffer_with(&[1, 2, 3, 4]);
+
+        buffer.drain(4);
+
+        assert_eq!(buffer.offset, 0);
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.filled(), &[] as &[u8]);
+    }
+
+    #[test]
+    fn drain_one_from_a_completely_full_buffer_stays_in_bounds() {
+        let mut buffer = NetworkBuffer::new();
+        buffer.offset = MAX_BUFFER_SIZE;
+        buffer.data[MAX_BUFFER_SIZE - 1] = 0xAB;
+
+        buffer.try_drain(1).expect("draining a full buffer failed");
+
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE - 1);
+        assert_eq!(buffer.data[MAX_BUFFER_SIZE - 2], 0xAB);
+    }
+
+    #[test]
+    fn try_drain_more_than_present_is_an_error() {
+        let mut buffer = buffer_with(&[1, 2, 3]);
+
+        assert!(matches!(buffer.try_drain(4), Err(Error::InvalidData)));
+
+        // The buffer is left untouched, so the caller can decide what to do about it.
+        assert_eq!(buffer.offset, 3);
+        assert_eq!(buffer.filled(), &[1, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempted to drain more bytes")]
+    fn drain_more_than_present_panics() {
+        let mut buffer = buffer_with(&[1, 2, 3]);
+        buffer.drain(4);
+    }
+
+    /// The soundness regression test for the original bug. `offset` is a public field, so
+    /// entirely safe downstream code could set it past the end of `data`. `drain` then derived
+    /// a raw copy length from it and handed that to `ptr::copy`, reading and writing tens of
+    /// kilobytes past the end of a heap-resident array.
+    #[test]
+    fn offset_beyond_capacity_never_reads_or_writes_out_of_bounds() {
+        let mut buffer = NetworkBuffer::new();
+        buffer.data[..4].copy_from_slice(&[1, 2, 3, 4]);
+
+        // The exact offset the vulnerable read loop produced from a single 64 KB burst.
+        buffer.offset = 65536;
+
+        // In 0.2.2 this was `ptr::copy(data + 3, data, 65533)` over a 16384-byte array.
+        buffer
+            .try_drain(3)
+            .expect("drain of a clamped buffer failed");
+
+        // The offset is clamped to capacity first, then the drain applies to the clamped value.
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE - 3);
+        assert_eq!(buffer.data[0], 4);
+    }
+
+    #[test]
+    fn absurd_offset_is_clamped_rather_than_overflowing() {
+        let mut buffer = NetworkBuffer::new();
+
+        // The documented safe-code path to UB in 0.2.2:
+        //     let mut b = grubbnet::buffer::NetworkBuffer::new();
+        //     b.offset = usize::MAX;
+        //     b.drain(0);
+        buffer.offset = usize::MAX;
+        buffer
+            .try_drain(0)
+            .expect("drain of a clamped buffer failed");
+
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+        assert_eq!(buffer.len(), MAX_BUFFER_SIZE);
+        assert!(buffer.is_full());
+    }
+
+    #[test]
+    fn absurd_offset_rejects_an_absurd_count() {
+        let mut buffer = NetworkBuffer::new();
+        buffer.offset = usize::MAX;
+
+        assert!(matches!(
+            buffer.try_drain(usize::MAX),
+            Err(Error::InvalidData)
+        ));
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn accessors_clamp_a_hostile_offset() {
+        let mut buffer = NetworkBuffer::new();
+        buffer.offset = usize::MAX;
+
+        assert_eq!(buffer.len(), MAX_BUFFER_SIZE);
+        assert_eq!(buffer.remaining(), 0);
+        assert!(buffer.is_full());
+        assert_eq!(buffer.filled().len(), MAX_BUFFER_SIZE);
+        assert_eq!(buffer.writable().len(), 0);
+    }
+
+    #[test]
+    fn writable_shrinks_as_the_buffer_fills() {
+        let mut buffer = NetworkBuffer::new();
+        assert_eq!(buffer.writable().len(), MAX_BUFFER_SIZE);
+
+        buffer.advance(100);
+
+        assert_eq!(buffer.writable().len(), MAX_BUFFER_SIZE - 100);
+        assert_eq!(buffer.remaining(), MAX_BUFFER_SIZE - 100);
+        assert!(!buffer.is_full());
+    }
+
+    #[test]
+    fn advance_saturates_at_capacity() {
+        let mut buffer = NetworkBuffer::new();
+
+        // A `Read` impl reporting more bytes than the slice it was handed must not be able to
+        // push the offset past the end of the array.
+        buffer.advance(usize::MAX);
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+
+        buffer.advance(usize::MAX);
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn repeated_full_size_advances_cannot_exceed_capacity() {
+        // Mirrors the vulnerable read loop: four reads of MAX_BUFFER_SIZE bytes each.
+        let mut buffer = NetworkBuffer::new();
+        for _ in 0..4 {
+            buffer.advance(MAX_BUFFER_SIZE);
+            assert!(buffer.offset <= MAX_BUFFER_SIZE);
+        }
+
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn clear_resets_everything() {
+        let mut buffer = buffer_with(&[1, 2, 3]);
+
+        buffer.clear();
+
+        assert_eq!(buffer.offset, 0);
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.data[0], 0);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,14 @@
 use crate::{
     buffer::NetworkBuffer,
     error::Result,
-    packet::{deserialize_packet_header, serialize_packet, Packet, PacketBody, PACKET_HEADER_SIZE},
-    send_bytes,
+    packet::{
+        parse_packet_header, serialize_packet, HeaderParse, Packet, PacketBody,
+        MAX_PACKET_BODY_SIZE, PACKET_HEADER_SIZE,
+    },
+    read_into_buffer, send_bytes, ReadOutcome,
 };
 use mio::{net::TcpStream, Events, Interest, Poll, Token};
-use std::{collections::VecDeque, io::Read};
+use std::collections::VecDeque;
 
 const LOCAL_TOKEN: Token = Token(0);
 const EVENTS_CAPACITY: usize = 4096;
@@ -90,55 +93,86 @@ impl Client {
                 LOCAL_TOKEN => {
                     // Handle reading
                     if event.is_readable() {
-                        loop {
-                            // Read until there are no more incoming bytes
-                            match self
-                                .tcp_stream
-                                .read(&mut self.buffer.data[self.buffer.offset..])
-                            {
-                                Ok(0) => {
-                                    // "Read" 0 bytes, which means we have been disconnected
-                                    net_events.push(ClientEvent::Disconnected);
-                                    self.is_disconnected = true;
-                                    break;
-                                }
-                                Ok(read_bytes) => {
-                                    // Read some bytes
-                                    self.buffer.offset += read_bytes;
-                                }
-                                Err(e) => {
-                                    // Socket is not ready anymore, stop reading
-                                    if e.kind() == std::io::ErrorKind::WouldBlock {
-                                        break;
-                                    } else {
-                                        net_events.push(ClientEvent::Disconnected);
+                        // Read until the socket runs dry or the buffer fills up. The
+                        // destination slice is recomputed on every iteration inside the helper.
+                        match read_into_buffer(&mut self.tcp_stream, &mut self.buffer) {
+                            // Socket ran dry, or the buffer filled up. Either way, process
+                            // whatever arrived. A full buffer is deliberately not treated as a
+                            // disconnect here; that check happens after packets are drained.
+                            ReadOutcome::WouldBlock | ReadOutcome::BufferFull => {}
+                            ReadOutcome::Closed => {
+                                // "Read" 0 bytes, which means we have been disconnected
+                                net_events.push(ClientEvent::Disconnected);
+                                self.is_disconnected = true;
+                            }
+                            ReadOutcome::Error(e) => {
+                                net_events.push(ClientEvent::Disconnected);
 
-                                        eprintln!("Unexpected error when reading bytes! {}", e);
-                                        self.is_disconnected = true;
-                                        break;
-                                    }
-                                }
+                                eprintln!("Unexpected error when reading bytes! {}", e);
+                                self.is_disconnected = true;
                             }
                         }
 
                         // Process incoming bytes into packets
-                        while let Ok(header) = deserialize_packet_header(&mut self.buffer) {
+                        loop {
+                            let header = match parse_packet_header(&self.buffer) {
+                                HeaderParse::Parsed(header) => header,
+                                // The rest of the header hasn't arrived yet. Wait for it.
+                                HeaderParse::Incomplete => break,
+                                HeaderParse::Invalid => {
+                                    // The header declares a body we will never accept, so the
+                                    // stream can never resynchronize.
+                                    eprintln!(
+                                        "Server sent a packet header declaring a body larger than the max body size ({} bytes)! Disconnecting.",
+                                        MAX_PACKET_BODY_SIZE
+                                    );
+
+                                    net_events.push(ClientEvent::Disconnected);
+                                    self.is_disconnected = true;
+                                    break;
+                                }
+                            };
+
                             // Now make sure we have enough bytes for at the rest of this packet
                             let packet_size = PACKET_HEADER_SIZE + (header.size as usize);
-                            if self.buffer.offset < packet_size {
+                            if self.buffer.len() < packet_size {
                                 break;
                             }
 
                             // Drain the packet bytes from the front of the buffer
-                            let bytes: &[u8] = &self.buffer.data[PACKET_HEADER_SIZE..packet_size];
-                            let body = bytes.to_vec();
-                            self.buffer.drain(packet_size);
+                            let body =
+                                self.buffer.filled()[PACKET_HEADER_SIZE..packet_size].to_vec();
+                            if self.buffer.try_drain(packet_size).is_err() {
+                                // Unreachable: `packet_size <= buffer.len()` was just checked.
+                                // Disconnect rather than spin on the same bytes.
+                                eprintln!(
+                                    "Failed to drain {} bytes from the incoming buffer! Disconnecting.",
+                                    packet_size
+                                );
+
+                                net_events.push(ClientEvent::Disconnected);
+                                self.is_disconnected = true;
+                                break;
+                            }
 
                             let packet = Packet { header, body };
 
                             self.incoming_packets.push_back(packet);
 
                             net_events.push(ClientEvent::ReceivedPacket(packet_size));
+                        }
+
+                        // MAX_BUFFER_SIZE is roughly twice MAX_PACKET_SIZE, so a peer speaking
+                        // the protocol can never leave the buffer completely full with no
+                        // complete packet in it. If it is still full here there is no room to
+                        // read more and nothing to process, so it would spin forever.
+                        if !self.is_disconnected && self.buffer.is_full() {
+                            eprintln!(
+                                "The incoming buffer is full but contains no complete packet! Disconnecting."
+                            );
+
+                            net_events.push(ClientEvent::Disconnected);
+                            self.is_disconnected = true;
                         }
                     }
 
@@ -182,15 +216,18 @@ impl Client {
         }
 
         // We're done processing events for this tick.
-        // Reregister for next tick.
-        self.poll
-            .registry()
-            .reregister(
-                &mut self.tcp_stream,
-                LOCAL_TOKEN,
-                Interest::READABLE | Interest::WRITABLE,
-            )
-            .unwrap();
+        // Reregister for next tick, unless we've disconnected: reregistering a socket we're
+        // about to drop can fail on a broken fd, and that failure is a panic.
+        if !self.is_disconnected {
+            self.poll
+                .registry()
+                .reregister(
+                    &mut self.tcp_stream,
+                    LOCAL_TOKEN,
+                    Interest::READABLE | Interest::WRITABLE,
+                )
+                .unwrap();
+        }
 
         net_events
     }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -17,13 +17,21 @@ pub use openssl::{
 pub fn decrypt(rsa: &Rsa<Private>, bytes: &[u8]) -> Result<(Vec<u8>, usize)> {
     let pkey = PKey::from_rsa(rsa.clone()).map_err(Error::OpenSsl)?;
     let mut decrypter = Decrypter::new(&pkey).map_err(Error::OpenSsl)?;
-    decrypter.set_rsa_padding(Padding::PKCS1_OAEP).map_err(Error::OpenSsl)?;
-    decrypter.set_rsa_oaep_md(MessageDigest::sha256()).map_err(Error::OpenSsl)?;
-    decrypter.set_rsa_mgf1_md(MessageDigest::sha256()).map_err(Error::OpenSsl)?;
+    decrypter
+        .set_rsa_padding(Padding::PKCS1_OAEP)
+        .map_err(Error::OpenSsl)?;
+    decrypter
+        .set_rsa_oaep_md(MessageDigest::sha256())
+        .map_err(Error::OpenSsl)?;
+    decrypter
+        .set_rsa_mgf1_md(MessageDigest::sha256())
+        .map_err(Error::OpenSsl)?;
 
     let buffer_len = decrypter.decrypt_len(bytes).map_err(Error::OpenSsl)?;
     let mut decrypted_bytes = vec![0u8; buffer_len];
-    let decrypted_len = decrypter.decrypt(bytes, &mut decrypted_bytes).map_err(Error::OpenSsl)?;
+    let decrypted_len = decrypter
+        .decrypt(bytes, &mut decrypted_bytes)
+        .map_err(Error::OpenSsl)?;
     Ok((decrypted_bytes, decrypted_len))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,14 @@ pub mod packet;
 pub mod crypto;
 
 use mio::net::TcpStream;
-use std::io::Write;
+use std::io::{Read, Write};
 
 pub use client::{Client, ClientEvent};
 pub use error::{Error, Result};
 pub use mio::Token;
 pub use server::{Server, ServerEvent};
+
+use crate::buffer::{NetworkBuffer, MAX_BUFFER_SIZE};
 
 pub enum PacketRecipient {
     All,
@@ -22,6 +24,83 @@ pub enum PacketRecipient {
     Exclude(Token),
     ExcludeMany(Vec<Token>),
     Include(Vec<Token>),
+}
+
+/// Why a read loop stopped pulling bytes off a socket.
+#[derive(Debug)]
+pub(crate) enum ReadOutcome {
+    /// The socket has no more bytes available right now. This is the normal exit.
+    WouldBlock,
+    /// The peer performed an orderly shutdown.
+    Closed,
+    /// The buffer filled up before the socket ran dry.
+    ///
+    /// `MAX_BUFFER_SIZE` is roughly twice `MAX_PACKET_SIZE`, so a well behaved peer can never
+    /// fill the buffer without also having put at least one complete packet in it. If the
+    /// buffer is still full once the caller has drained every complete packet, the peer is
+    /// misbehaving and the connection should be dropped.
+    BufferFull,
+    /// A genuine I/O error.
+    Error(std::io::Error),
+}
+
+/// Reads from `reader` into `buffer` until the socket runs dry or the buffer fills up.
+///
+/// Generic over `Read` so the loop's bounds handling can be unit tested without a real socket.
+///
+/// The destination slice is recomputed on every iteration. Hoisting it out of the loop freezes
+/// its length at `MAX_BUFFER_SIZE - offset_at_entry` while `offset` keeps accumulating inside
+/// the loop, which let a single unauthenticated 64 KB burst drive `offset` to 65536 on a
+/// 16384-byte array. Every length derived from that offset afterwards - notably the copy length
+/// in `NetworkBuffer::drain` - was then out of bounds. Do not hoist it.
+pub(crate) fn read_into_buffer<R: Read>(reader: &mut R, buffer: &mut NetworkBuffer) -> ReadOutcome {
+    // `offset` is a public field, so it may hold anything on entry. Re-establish the type
+    // invariant up front so that it holds unconditionally on exit too.
+    buffer.normalize();
+
+    loop {
+        // Never hand `read` a zero length slice. `Read::read` is documented to return `Ok(0)`
+        // for an empty destination, which is indistinguishable from an orderly peer shutdown,
+        // so a full buffer would otherwise be reported as a graceful disconnect.
+        if buffer.is_full() {
+            return ReadOutcome::BufferFull;
+        }
+
+        let destination = buffer.writable();
+        let capacity = destination.len();
+
+        match reader.read(destination) {
+            Ok(0) => return ReadOutcome::Closed,
+            Ok(read_bytes) => {
+                // Hard invariant: the offset must never leave the backing array. `advance`
+                // clamps at runtime; this catches a lying `Read` implementation in dev builds.
+                debug_assert!(
+                    read_bytes <= capacity,
+                    "Read reported {} bytes into a {} byte slice",
+                    read_bytes,
+                    capacity
+                );
+
+                buffer.advance(read_bytes);
+
+                debug_assert!(
+                    buffer.offset <= MAX_BUFFER_SIZE,
+                    "Buffer offset ({}) escaped the backing array ({} bytes)",
+                    buffer.offset,
+                    MAX_BUFFER_SIZE
+                );
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                // Interrupted before any bytes were read, so just retry.
+                continue;
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                // Socket is not ready anymore, stop reading.
+                return ReadOutcome::WouldBlock;
+            }
+            Err(e) => return ReadOutcome::Error(e),
+        }
+    }
 }
 
 /// Send some bytes to a socket.
@@ -76,7 +155,7 @@ fn write_bytes<W: Write>(socket: &mut W, buffer: &[u8]) -> Result<usize> {
 mod tests {
     use super::*;
     use std::collections::VecDeque;
-    use std::io::{self, ErrorKind, Write};
+    use std::io::{self, ErrorKind, Read, Write};
 
     /// A `Write` implementation that returns a scripted sequence of results,
     /// recording everything it accepts so tests can assert on byte ordering.
@@ -177,5 +256,184 @@ mod tests {
             Err(Error::Io(e)) => assert_eq!(e.kind(), ErrorKind::ConnectionReset),
             other => panic!("expected Io error, got {:?}", other),
         }
+    }
+
+    /// A `Read` implementation that returns a scripted sequence of results, mirroring
+    /// `MockWriter`. `Ok(n)` fills the destination with `n` bytes of `fill`, saturated at the
+    /// destination's length - a real `Read` can never report more bytes than the slice holds,
+    /// and pretending otherwise would only test the clamp already covered in `buffer.rs`.
+    struct MockReader {
+        results: VecDeque<io::Result<usize>>,
+        fill: u8,
+    }
+
+    impl MockReader {
+        fn new(results: Vec<io::Result<usize>>) -> Self {
+            MockReader {
+                results: results.into_iter().collect(),
+                fill: 0xAB,
+            }
+        }
+    }
+
+    impl Read for MockReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            match self.results.pop_front() {
+                Some(Ok(n)) => {
+                    let n = n.min(buf.len());
+                    for byte in buf[..n].iter_mut() {
+                        *byte = self.fill;
+                    }
+                    Ok(n)
+                }
+                Some(Err(e)) => Err(e),
+                // Default once the script is exhausted: the socket has run dry.
+                None => Err(io::Error::from(ErrorKind::WouldBlock)),
+            }
+        }
+    }
+
+    /// The core regression test for the 0.2.2 heap corruption.
+    ///
+    /// The vulnerable loop computed `&mut data[offset..]` once, outside the loop, so four
+    /// `MAX_BUFFER_SIZE` reads drove `offset` to 65536 on a 16384-byte array. Recomputing the
+    /// destination each iteration means the second read is handed a zero-length slice, the
+    /// buffer-full guard fires first, and `offset` tops out at capacity.
+    #[test]
+    fn repeated_full_size_reads_cannot_push_the_offset_past_capacity() {
+        let mut reader = MockReader::new(vec![
+            Ok(MAX_BUFFER_SIZE),
+            Ok(MAX_BUFFER_SIZE),
+            Ok(MAX_BUFFER_SIZE),
+            Ok(MAX_BUFFER_SIZE),
+            Err(io::Error::from(ErrorKind::WouldBlock)),
+        ]);
+        let mut buffer = NetworkBuffer::new();
+
+        let outcome = read_into_buffer(&mut reader, &mut buffer);
+
+        assert!(matches!(outcome, ReadOutcome::BufferFull));
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+        assert!(buffer.offset <= MAX_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn many_partial_reads_accumulate_without_exceeding_capacity() {
+        // 40 reads of 1 KB into a 16 KB buffer: the first 16 fill it, the rest cannot.
+        let chunk = 1024;
+        let results: Vec<io::Result<usize>> = (0..40).map(|_| Ok(chunk)).collect();
+        let mut reader = MockReader::new(results);
+        let mut buffer = NetworkBuffer::new();
+
+        let outcome = read_into_buffer(&mut reader, &mut buffer);
+
+        assert!(matches!(outcome, ReadOutcome::BufferFull));
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn reads_append_rather_than_overwrite() {
+        // Two reads landing in a single readable event must not overwrite each other. The
+        // frozen slice silently corrupted framing exactly here.
+        let mut reader = MockReader::new(vec![Ok(4), Ok(4)]);
+        let mut buffer = NetworkBuffer::new();
+
+        let outcome = read_into_buffer(&mut reader, &mut buffer);
+
+        assert!(matches!(outcome, ReadOutcome::WouldBlock));
+        assert_eq!(buffer.offset, 8);
+        assert_eq!(buffer.filled(), &[0xAB; 8]);
+    }
+
+    #[test]
+    fn appends_after_a_previous_partial_packet() {
+        let mut buffer = NetworkBuffer::new();
+        buffer.data[..3].copy_from_slice(&[1, 2, 3]);
+        buffer.offset = 3;
+
+        let mut reader = MockReader::new(vec![Ok(2)]);
+        read_into_buffer(&mut reader, &mut buffer);
+
+        assert_eq!(buffer.offset, 5);
+        assert_eq!(buffer.filled(), &[1, 2, 3, 0xAB, 0xAB]);
+    }
+
+    #[test]
+    fn a_full_buffer_is_reported_as_full_not_as_a_disconnect() {
+        // `Read::read` returns `Ok(0)` for a zero-length destination, which the old code
+        // treated as an orderly peer shutdown. A full buffer must never look like a disconnect.
+        let mut reader = MockReader::new(vec![Ok(0)]);
+        let mut buffer = NetworkBuffer::new();
+        buffer.offset = MAX_BUFFER_SIZE;
+
+        let outcome = read_into_buffer(&mut reader, &mut buffer);
+
+        assert!(matches!(outcome, ReadOutcome::BufferFull));
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn a_hostile_offset_is_clamped_before_reading() {
+        let mut reader = MockReader::new(vec![Ok(16)]);
+        let mut buffer = NetworkBuffer::new();
+        buffer.offset = usize::MAX;
+
+        let outcome = read_into_buffer(&mut reader, &mut buffer);
+
+        assert!(matches!(outcome, ReadOutcome::BufferFull));
+        assert_eq!(buffer.offset, MAX_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn a_closed_socket_is_reported_as_closed() {
+        let mut reader = MockReader::new(vec![Ok(4), Ok(0)]);
+        let mut buffer = NetworkBuffer::new();
+
+        let outcome = read_into_buffer(&mut reader, &mut buffer);
+
+        assert!(matches!(outcome, ReadOutcome::Closed));
+        assert_eq!(buffer.offset, 4);
+    }
+
+    #[test]
+    fn would_block_on_the_first_read_buffers_nothing() {
+        let mut reader = MockReader::new(vec![Err(io::Error::from(ErrorKind::WouldBlock))]);
+        let mut buffer = NetworkBuffer::new();
+
+        let outcome = read_into_buffer(&mut reader, &mut buffer);
+
+        assert!(matches!(outcome, ReadOutcome::WouldBlock));
+        assert_eq!(buffer.offset, 0);
+    }
+
+    #[test]
+    fn interrupted_reads_are_retried() {
+        let mut reader = MockReader::new(vec![
+            Err(io::Error::from(ErrorKind::Interrupted)),
+            Ok(6),
+            Err(io::Error::from(ErrorKind::WouldBlock)),
+        ]);
+        let mut buffer = NetworkBuffer::new();
+
+        let outcome = read_into_buffer(&mut reader, &mut buffer);
+
+        assert!(matches!(outcome, ReadOutcome::WouldBlock));
+        assert_eq!(buffer.offset, 6);
+    }
+
+    #[test]
+    fn a_real_read_error_is_surfaced() {
+        let mut reader = MockReader::new(vec![
+            Ok(2),
+            Err(io::Error::from(ErrorKind::ConnectionReset)),
+        ]);
+        let mut buffer = NetworkBuffer::new();
+
+        match read_into_buffer(&mut reader, &mut buffer) {
+            ReadOutcome::Error(e) => assert_eq!(e.kind(), ErrorKind::ConnectionReset),
+            other => panic!("expected an Error outcome, got {:?}", other),
+        }
+
+        assert_eq!(buffer.offset, 2);
     }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -13,7 +13,7 @@ pub const MAX_PACKET_SIZE: usize = PACKET_HEADER_SIZE + MAX_PACKET_BODY_SIZE;
 
 /// PacketHeader
 /// The header included with every packet. Contains the packet body size and packet id.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PacketHeader {
     pub size: u16,
     pub id: u8,
@@ -63,29 +63,224 @@ pub fn serialize_packet(body: Box<dyn PacketBody>) -> Result<Vec<u8>, Error> {
     Ok(data)
 }
 
-pub fn deserialize_packet_header(buffer: &mut NetworkBuffer) -> Result<PacketHeader, Error> {
-    let mut reader = Cursor::new(&buffer.data[..]);
+/// The outcome of attempting to read a packet header off the front of a buffer.
+///
+/// The public [`deserialize_packet_header`] collapses this to a `Result`, which cannot express
+/// the difference between "the rest of the header has not arrived yet" and "the peer sent
+/// something illegal". Internally that distinction matters: the first means wait for more
+/// bytes, the second means drop the connection.
+#[derive(Debug)]
+pub(crate) enum HeaderParse {
+    /// A complete, in-range header was parsed off the front of the buffer.
+    Parsed(PacketHeader),
+    /// Fewer than [`PACKET_HEADER_SIZE`] bytes are buffered. Wait for more data.
+    Incomplete,
+    /// The header declares a body larger than [`MAX_PACKET_BODY_SIZE`]. Protocol violation.
+    Invalid,
+}
+
+/// Reads a packet header off the front of `buffer` without consuming it.
+///
+/// Never inspects a byte that has not actually been received: prior to 0.2.3 this read three
+/// bytes unconditionally, so a one or two byte header was completed with stale bytes left over
+/// from earlier traffic. Never logs either, so a peer dribbling partial headers cannot be used
+/// to flood the host's logs.
+pub(crate) fn parse_packet_header(buffer: &NetworkBuffer) -> HeaderParse {
+    // Only bytes that have actually arrived may be parsed.
+    if buffer.len() < PACKET_HEADER_SIZE {
+        return HeaderParse::Incomplete;
+    }
+
+    let mut reader = Cursor::new(&buffer.data[..PACKET_HEADER_SIZE]);
 
     // Read body size
-    let body_size = reader.read_u16::<NetworkEndian>()? as usize;
+    let body_size = match reader.read_u16::<NetworkEndian>() {
+        Ok(size) => size as usize,
+        Err(_) => return HeaderParse::Incomplete,
+    };
 
-    // If the packet is too big, kick the client so we have some basic protection from being overloaded
+    // If the packet is too big, the caller should kick the client so we have some basic
+    // protection from being overloaded
     if body_size >= MAX_PACKET_BODY_SIZE {
-        eprintln!(
-            "Packet body is {} bytes, but max body size is ({} bytes)!",
-            body_size, MAX_PACKET_BODY_SIZE
-        );
-
-        return Err(Error::InvalidData);
+        return HeaderParse::Invalid;
     }
 
     // Read packet id
-    let packet_id = reader.read_u8()?;
-
-    let header = PacketHeader {
-        size: body_size as u16,
-        id: packet_id,
+    let packet_id = match reader.read_u8() {
+        Ok(id) => id,
+        Err(_) => return HeaderParse::Incomplete,
     };
 
-    Ok(header)
+    HeaderParse::Parsed(PacketHeader {
+        size: body_size as u16,
+        id: packet_id,
+    })
+}
+
+/// Reads a packet header off the front of `buffer` without consuming it.
+///
+/// Returns `Error::InvalidData` if fewer than [`PACKET_HEADER_SIZE`] bytes are buffered, or if
+/// the header declares a body larger than [`MAX_PACKET_BODY_SIZE`].
+pub fn deserialize_packet_header(buffer: &mut NetworkBuffer) -> Result<PacketHeader, Error> {
+    match parse_packet_header(buffer) {
+        HeaderParse::Parsed(header) => Ok(header),
+        HeaderParse::Incomplete | HeaderParse::Invalid => Err(Error::InvalidData),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buffer_with(bytes: &[u8]) -> NetworkBuffer {
+        let mut buffer = NetworkBuffer::new();
+        buffer.data[..bytes.len()].copy_from_slice(bytes);
+        buffer.offset = bytes.len();
+        buffer
+    }
+
+    #[test]
+    fn parses_a_complete_header() {
+        let buffer = buffer_with(&[0x00, 0x10, 0x07]);
+
+        match parse_packet_header(&buffer) {
+            HeaderParse::Parsed(header) => {
+                assert_eq!(header.size, 16);
+                assert_eq!(header.id, 0x07);
+            }
+            other => panic!("expected a parsed header, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_an_empty_body_header() {
+        let buffer = buffer_with(&[0x00, 0x00, 0x00]);
+
+        match parse_packet_header(&buffer) {
+            HeaderParse::Parsed(header) => {
+                assert_eq!(header.size, 0);
+                assert_eq!(header.id, 0x00);
+            }
+            other => panic!("expected a parsed header, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn an_empty_buffer_is_incomplete() {
+        let buffer = NetworkBuffer::new();
+        assert!(matches!(
+            parse_packet_header(&buffer),
+            HeaderParse::Incomplete
+        ));
+    }
+
+    /// Prior to 0.2.3 a partial header was completed with whatever stale bytes happened to be
+    /// left in the buffer from earlier traffic.
+    #[test]
+    fn a_partial_header_is_never_completed_with_stale_bytes() {
+        let mut buffer = NetworkBuffer::new();
+
+        // Stale bytes from a previous packet that would decode to an enormous body size.
+        buffer.data[..3].copy_from_slice(&[0xFF, 0xFF, 0xFF]);
+
+        // ...but only two bytes have actually arrived.
+        buffer.offset = 2;
+
+        assert!(matches!(
+            parse_packet_header(&buffer),
+            HeaderParse::Incomplete
+        ));
+    }
+
+    #[test]
+    fn an_oversized_body_is_invalid() {
+        let buffer = buffer_with(&[0xFF, 0xFF, 0x00]);
+        assert!(matches!(parse_packet_header(&buffer), HeaderParse::Invalid));
+    }
+
+    #[test]
+    fn a_body_at_the_size_limit_is_invalid() {
+        let size = (MAX_PACKET_BODY_SIZE as u16).to_be_bytes();
+        let buffer = buffer_with(&[size[0], size[1], 0x00]);
+        assert!(matches!(parse_packet_header(&buffer), HeaderParse::Invalid));
+    }
+
+    #[test]
+    fn the_largest_legal_body_is_accepted() {
+        let size = (MAX_PACKET_BODY_SIZE as u16 - 1).to_be_bytes();
+        let buffer = buffer_with(&[size[0], size[1], 0x00]);
+
+        match parse_packet_header(&buffer) {
+            HeaderParse::Parsed(header) => {
+                assert_eq!(header.size as usize, MAX_PACKET_BODY_SIZE - 1)
+            }
+            other => panic!("expected a parsed header, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn the_public_wrapper_reports_both_failures_as_invalid_data() {
+        let mut short = buffer_with(&[0x00]);
+        assert!(matches!(
+            deserialize_packet_header(&mut short),
+            Err(Error::InvalidData)
+        ));
+
+        let mut oversized = buffer_with(&[0xFF, 0xFF, 0x00]);
+        assert!(matches!(
+            deserialize_packet_header(&mut oversized),
+            Err(Error::InvalidData)
+        ));
+    }
+
+    #[test]
+    fn a_hostile_offset_does_not_produce_a_header() {
+        // `offset` is public, so it can be anything. It must still never be trusted as a length.
+        let mut buffer = NetworkBuffer::new();
+        buffer.offset = usize::MAX;
+
+        // Clamped to a full buffer of zeroes, which is a legal empty-body header.
+        match parse_packet_header(&buffer) {
+            HeaderParse::Parsed(header) => {
+                assert_eq!(header.size, 0);
+                assert_eq!(header.id, 0);
+            }
+            other => panic!("expected a parsed header, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn a_serialized_packet_round_trips_through_the_header_parser() {
+        struct Body(Vec<u8>);
+
+        impl PacketBody for Body {
+            fn box_clone(&self) -> Box<dyn PacketBody> {
+                Box::new(Body(self.0.clone()))
+            }
+
+            fn serialize(&self) -> Result<Vec<u8>, Error> {
+                Ok(self.0.clone())
+            }
+
+            fn deserialize(data: &[u8]) -> Result<Self, Error> {
+                Ok(Body(data.to_vec()))
+            }
+
+            fn id(&self) -> u8 {
+                0x2A
+            }
+        }
+
+        let data = serialize_packet(Box::new(Body(vec![1, 2, 3, 4, 5]))).unwrap();
+        assert_eq!(data.len(), PACKET_HEADER_SIZE + 5);
+
+        let buffer = buffer_with(&data);
+        match parse_packet_header(&buffer) {
+            HeaderParse::Parsed(header) => {
+                assert_eq!(header.size, 5);
+                assert_eq!(header.id, 0x2A);
+            }
+            other => panic!("expected a parsed header, got {:?}", other),
+        }
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,11 @@
 use crate::{
-    buffer::NetworkBuffer,
+    buffer::{NetworkBuffer, MAX_BUFFER_SIZE},
     error::{Error, Result},
-    packet::{deserialize_packet_header, serialize_packet, Packet, PacketBody, PACKET_HEADER_SIZE},
-    send_bytes, PacketRecipient,
+    packet::{
+        parse_packet_header, serialize_packet, HeaderParse, Packet, PacketBody,
+        MAX_PACKET_BODY_SIZE, PACKET_HEADER_SIZE,
+    },
+    read_into_buffer, send_bytes, PacketRecipient, ReadOutcome,
 };
 use mio::{
     net::{TcpListener, TcpStream},
@@ -10,7 +13,6 @@ use mio::{
 };
 use std::{
     collections::{HashMap, VecDeque},
-    io::Read,
     net::SocketAddr,
 };
 
@@ -90,6 +92,13 @@ impl Server {
     /// Get the maximum number of connections allowed.
     pub fn connection_limit(&self) -> usize {
         self.connection_limit
+    }
+
+    /// The address this server is listening on.
+    ///
+    /// Useful when hosting on port 0 and letting the OS pick a free port.
+    pub fn local_addr(&self) -> Result<SocketAddr> {
+        Ok(self.tcp_listener.local_addr()?)
     }
 
     /// Drain any incoming packets and return them.
@@ -230,50 +239,117 @@ impl Server {
 
                     // Handle reading
                     if event.is_readable() {
-                        // Loop and read bytes into this connections buffer, until there are no more incoming bytes
-                        let buffer = &mut conn.buffer.data[conn.buffer.offset..];
-                        loop {
-                            match conn.socket.read(buffer) {
-                                Ok(0) => {
-                                    // "Read" 0 bytes, which means the socket has closed
-                                    conn.is_disconnected = true;
-                                    break;
-                                }
-                                Ok(read_bytes) => {
-                                    // Read some bytes
-                                    conn.buffer.offset += read_bytes;
-                                }
-                                Err(e) => {
-                                    // Socket is not ready anymore, stop reading
-                                    if e.kind() == std::io::ErrorKind::WouldBlock {
-                                        break;
-                                    } else {
-                                        eprintln!("Unexpected error when reading bytes from connection {}! {}", conn.token.0, e);
-                                        conn.is_disconnected = true;
-                                        break;
-                                    }
-                                }
+                        // Read bytes into this connection's buffer until the socket runs dry
+                        // or the buffer fills up. The destination slice is recomputed on every
+                        // iteration inside the helper: hoisting it out of the loop is what let
+                        // an unauthenticated 64 KB burst drive `offset` to 65536 on a
+                        // 16384-byte array in 0.2.2.
+                        //
+                        // At most one bufferful is taken per readable event, so a peer sending
+                        // a firehose of bytes cannot starve the other connections. The
+                        // reregister at the end of this tick re-arms readiness for the rest.
+                        let read_outcome = read_into_buffer(&mut conn.socket, &mut conn.buffer);
+
+                        // Hard invariant: the read path must never leave the buffer offset past
+                        // the end of the backing array. 0.2.2 violated this and then fed the
+                        // resulting out-of-range length straight into an unsafe pointer copy.
+                        debug_assert!(
+                            conn.buffer.offset <= MAX_BUFFER_SIZE,
+                            "Connection {} buffer offset ({}) escaped the backing array ({} bytes)",
+                            conn.token.0,
+                            conn.buffer.offset,
+                            MAX_BUFFER_SIZE
+                        );
+
+                        if conn.buffer.offset > MAX_BUFFER_SIZE {
+                            eprintln!(
+                                "Connection {} buffer offset ({}) exceeded the maximum buffer size ({} bytes)! Dropping connection.",
+                                conn.token.0, conn.buffer.offset, MAX_BUFFER_SIZE
+                            );
+
+                            conn.buffer.offset = MAX_BUFFER_SIZE;
+                            conn.is_disconnected = true;
+                        }
+
+                        match read_outcome {
+                            // Socket ran dry, or the buffer filled up. Either way, process
+                            // whatever arrived. A full buffer is deliberately not treated as a
+                            // disconnect here; that check happens after packets are drained.
+                            ReadOutcome::WouldBlock | ReadOutcome::BufferFull => {}
+                            ReadOutcome::Closed => {
+                                // "Read" 0 bytes, which means the socket has closed
+                                conn.is_disconnected = true;
+                            }
+                            ReadOutcome::Error(e) => {
+                                eprintln!(
+                                    "Unexpected error when reading bytes from connection {}! {}",
+                                    conn.token.0, e
+                                );
+
+                                conn.is_disconnected = true;
                             }
                         }
 
                         // Process incoming bytes into packets
-                        while let Ok(header) = deserialize_packet_header(&mut conn.buffer) {
+                        loop {
+                            let header = match parse_packet_header(&conn.buffer) {
+                                HeaderParse::Parsed(header) => header,
+                                // The rest of the header hasn't arrived yet. Wait for it.
+                                HeaderParse::Incomplete => break,
+                                HeaderParse::Invalid => {
+                                    // The header declares a body we will never accept, so the
+                                    // stream can never resynchronize. Kick the client so we
+                                    // have some basic protection from being overloaded.
+                                    eprintln!(
+                                        "Connection {} sent a packet header declaring a body larger than the max body size ({} bytes)! Dropping connection.",
+                                        conn.token.0, MAX_PACKET_BODY_SIZE
+                                    );
+
+                                    conn.is_disconnected = true;
+                                    break;
+                                }
+                            };
+
                             // Now make sure we have enough bytes for at the rest of this packet
                             let packet_size = PACKET_HEADER_SIZE + (header.size as usize);
-                            if conn.buffer.offset < packet_size {
+                            if conn.buffer.len() < packet_size {
                                 break;
                             }
 
                             // Drain the packet bytes from the front of the buffer
-                            let bytes: &[u8] = &conn.buffer.data[PACKET_HEADER_SIZE..packet_size];
-                            let body = bytes.to_vec();
-                            conn.buffer.drain(packet_size);
+                            let body =
+                                conn.buffer.filled()[PACKET_HEADER_SIZE..packet_size].to_vec();
+                            if conn.buffer.try_drain(packet_size).is_err() {
+                                // Unreachable: `packet_size <= buffer.len()` was just checked.
+                                // Drop the connection rather than spin on the same bytes.
+                                eprintln!(
+                                    "Failed to drain {} bytes from connection {}'s buffer! Dropping connection.",
+                                    packet_size, conn.token.0
+                                );
+
+                                conn.is_disconnected = true;
+                                break;
+                            }
 
                             let packet = Packet { header, body };
 
                             self.incoming_packets.push_back((token, packet));
 
                             net_events.push(ServerEvent::ReceivedPacket(conn.token, packet_size));
+                        }
+
+                        // MAX_BUFFER_SIZE is roughly twice MAX_PACKET_SIZE, so a peer speaking
+                        // the protocol can never leave the buffer completely full with no
+                        // complete packet in it. If it is still full here, the peer is either
+                        // desynced or deliberately wedging the connection: there is no room to
+                        // read more and nothing to process, so it would spin forever.
+                        if !conn.is_disconnected && conn.buffer.is_full() {
+                            eprintln!(
+                                "Connection {}'s buffer is full but contains no complete packet! Dropping connection.",
+                                conn.token.0
+                            );
+
+                            conn.is_disconnected = true;
                         }
                     }
 
@@ -314,20 +390,35 @@ impl Server {
                     }
 
                     // We're done processing events for this connection for this tick.
-                    // Reregister for next tick.
-                    self.poll
-                        .registry()
-                        .reregister(
-                            &mut conn.socket,
-                            conn.token,
-                            Interest::READABLE | Interest::WRITABLE,
-                        )
-                        .unwrap_or_else(|e| {
-                            panic!(
-                                "Failed to reregister poll for connection (Token {}). {}",
-                                token.0, e
+                    // Reregister for next tick, unless it's on its way out: reregistering a
+                    // socket we're about to drop can fail on a broken fd, and that failure is
+                    // a panic. A misbehaving peer must not be able to take the server down.
+                    //
+                    // Skipping it here is safe because `is_disconnected` is not touched again
+                    // before the `retain` at the end of this tick removes exactly these
+                    // connections, so a connection that survives the tick is always re-armed.
+                    //
+                    // Note that in the `BufferFull` case above we stop reading before the
+                    // socket returns `WouldBlock`, and mio only guarantees another readiness
+                    // event after a full drain. This reregister is what re-arms readiness for
+                    // the leftover bytes: it maps to `EPOLL_CTL_MOD` on epoll and to a
+                    // re-issued AFD poll on Windows IOCP, both of which report a socket that
+                    // already has data pending.
+                    if !conn.is_disconnected {
+                        self.poll
+                            .registry()
+                            .reregister(
+                                &mut conn.socket,
+                                conn.token,
+                                Interest::READABLE | Interest::WRITABLE,
                             )
-                        });
+                            .unwrap_or_else(|e| {
+                                panic!(
+                                    "Failed to reregister poll for connection (Token {}). {}",
+                                    token.0, e
+                                )
+                            });
+                    }
                 }
             }
         }

--- a/tests/server_read_path.rs
+++ b/tests/server_read_path.rs
@@ -1,0 +1,458 @@
+//! Integration tests for the server read path.
+//!
+//! These host a real `Server` on `127.0.0.1:0` and drive it with a plain
+//! `std::net::TcpStream`, exercising the socket -> buffer -> packet pipeline end to end.
+//!
+//! The headline test here (`sixty_four_kilobyte_burst_does_not_corrupt_the_server`) is the
+//! regression test for the remote heap corruption fixed in 0.2.3: an unauthenticated peer that
+//! connected and wrote 64 KB in one burst drove the connection's buffer offset to 65536 on a
+//! 16384-byte array, which `NetworkBuffer::drain` then handed to an unchecked `ptr::copy`.
+
+use grubbnet::{Server, ServerEvent, Token};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+const MAX_BUFFER_SIZE: usize = 1024 * 16;
+const PACKET_HEADER_SIZE: usize = 3;
+const MAX_PACKET_BODY_SIZE: usize = 8192;
+
+/// How long a test will wait for the server to reach the state it expects.
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Encodes a packet exactly as it appears on the wire: a big-endian u16 body size, a u8 packet
+/// id, then the body.
+fn packet_bytes(id: u8, body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(PACKET_HEADER_SIZE + body.len());
+    out.extend_from_slice(&(body.len() as u16).to_be_bytes());
+    out.push(id);
+    out.extend_from_slice(body);
+    out
+}
+
+/// A running summary of everything the server has reported. `ServerEvent` is neither `Clone`
+/// nor `Debug`, so it gets tallied as it arrives.
+#[derive(Default)]
+struct Tally {
+    connected: Vec<Token>,
+    disconnected: Vec<Token>,
+    rejected: usize,
+    received: usize,
+    sent: usize,
+    unrecognized: usize,
+    packets: Vec<(Token, u8, Vec<u8>)>,
+}
+
+impl Tally {
+    fn absorb(&mut self, server: &mut Server) {
+        for event in server.tick() {
+            match event {
+                ServerEvent::ClientConnected(token, _addr) => self.connected.push(token),
+                ServerEvent::ClientDisconnected(token) => self.disconnected.push(token),
+                ServerEvent::ConnectionRejected(_addr) => self.rejected += 1,
+                ServerEvent::ReceivedPacket(_token, _bytes) => self.received += 1,
+                ServerEvent::SentPacket(_token, _bytes) => self.sent += 1,
+                _ => self.unrecognized += 1,
+            }
+        }
+
+        for (token, packet) in server.drain_incoming_packets() {
+            self.packets.push((token, packet.header.id, packet.body));
+        }
+    }
+}
+
+/// Ticks `server` until `stop` is satisfied or [`TIMEOUT`] elapses.
+///
+/// Returns whether `stop` was satisfied. Tests that expect a steady state (e.g. "the connection
+/// is *not* dropped") deliberately ignore the return value and assert on the tally instead.
+fn pump(server: &mut Server, tally: &mut Tally, stop: impl Fn(&Tally) -> bool) -> bool {
+    let deadline = Instant::now() + TIMEOUT;
+
+    while Instant::now() < deadline {
+        tally.absorb(server);
+
+        if stop(tally) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Ticks the server for a fixed stretch of wall clock time, without an early exit.
+fn pump_for(server: &mut Server, tally: &mut Tally, duration: Duration) {
+    let deadline = Instant::now() + duration;
+
+    while Instant::now() < deadline {
+        tally.absorb(server);
+    }
+}
+
+fn host() -> (Server, SocketAddr) {
+    let server = Server::host("127.0.0.1", 0, 32).expect("failed to host test server");
+    let addr = server
+        .local_addr()
+        .expect("failed to read the server address");
+
+    (server, addr)
+}
+
+/// Spawns a peer that writes `payload` in one burst, then holds the connection open until the
+/// server closes it (or the read times out), so the server is never the one seeing EOF first.
+///
+/// The write happens on its own thread because a blocking `write_all` of more than a socket
+/// buffer's worth of bytes will not complete until the server starts reading, and the server
+/// only reads while the test thread is ticking it.
+fn spawn_peer(addr: SocketAddr, payload: Vec<u8>) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut stream = TcpStream::connect(addr).expect("peer failed to connect");
+        stream
+            .set_nodelay(true)
+            .expect("peer failed to set nodelay");
+        stream
+            .set_read_timeout(Some(TIMEOUT))
+            .expect("peer failed to set a read timeout");
+
+        // The server may drop us mid-write, which is the point of some of these tests.
+        let _ = stream.write_all(&payload);
+        let _ = stream.flush();
+
+        // Block until the server closes the connection, so it stays open in the meantime.
+        let mut sink = [0u8; 1024];
+        let _ = stream.read(&mut sink);
+    })
+}
+
+/// The regression test for the 0.2.2 remote heap corruption.
+///
+/// One anonymous `connect()` plus one ~64 KB `write()`. The first three bytes are a valid
+/// header declaring a zero-length body (`packet_size == PACKET_HEADER_SIZE == 3`), which is the
+/// combination that reached the vulnerable `drain`: the safe, bounds-checked slice on the
+/// preceding line is `&data[3..3]`, an in-bounds empty slice, so it never fires.
+///
+/// In 0.2.2 the destination slice was computed once outside the read loop while `offset` kept
+/// accumulating inside it, so four 16384-byte reads left `offset == 65536`. `drain(3)` then ran
+/// `ptr::copy(data + 3, data, 65533)` over a 16384-byte array living in a `HashMap`-owned
+/// `Connection` - a ~48 KB out-of-bounds read and write across the heap, next to the
+/// `VecDeque<Box<dyn PacketBody>>` vtable pointers.
+#[test]
+fn sixty_four_kilobyte_burst_does_not_corrupt_the_server() {
+    let (mut server, addr) = host();
+
+    // 64 KB: a valid empty-body header, then filler that cannot be resynchronized into a
+    // packet, so the connection is expected to be dropped rather than parsed forever.
+    let mut payload = vec![0xFFu8; 65536];
+    payload[0] = 0x00;
+    payload[1] = 0x00;
+    payload[2] = 0x00;
+
+    let peer = spawn_peer(addr, payload);
+
+    let mut tally = Tally::default();
+    assert!(
+        pump(&mut server, &mut tally, |t| !t.disconnected.is_empty()),
+        "the server never dropped the misbehaving connection"
+    );
+
+    // The process survived the burst.
+    assert_eq!(tally.connected.len(), 1, "expected exactly one connection");
+    assert_eq!(
+        tally.disconnected, tally.connected,
+        "the connection that was dropped is not the one that connected"
+    );
+    assert_eq!(tally.unrecognized, 0, "an unrecognized event was reported");
+
+    // The valid empty packet at the front of the burst was delivered intact before the
+    // connection was dropped.
+    assert_eq!(tally.packets.len(), 1, "expected the one valid packet");
+    assert_eq!(tally.packets[0].1, 0x00);
+    assert!(tally.packets[0].2.is_empty());
+
+    // And the connection was actually reaped, not just reported.
+    assert_eq!(
+        server.num_connections(),
+        0,
+        "the dropped connection was not removed"
+    );
+
+    peer.join().expect("peer thread panicked");
+}
+
+/// The same shape of attack, but with a payload that is entirely zeroes.
+///
+/// Every three bytes decode as a legal empty packet, so this is the variant that keeps the
+/// connection alive while driving the read loop as hard as possible. It is the harshest test of
+/// the read/drain cycle: thousands of `try_drain` calls against a completely full buffer.
+#[test]
+fn a_full_buffer_of_empty_packets_is_drained_without_corruption() {
+    let (mut server, addr) = host();
+
+    let payload = vec![0x00u8; 65536];
+    let expected = payload.len() / PACKET_HEADER_SIZE;
+
+    let peer = spawn_peer(addr, payload);
+
+    let mut tally = Tally::default();
+    assert!(
+        pump(&mut server, &mut tally, |t| t.packets.len() >= expected),
+        "only {} of {} empty packets arrived",
+        tally.packets.len(),
+        expected
+    );
+
+    assert_eq!(tally.connected.len(), 1);
+    assert!(
+        tally
+            .packets
+            .iter()
+            .all(|(_, id, body)| *id == 0 && body.is_empty()),
+        "an empty packet decoded to something else"
+    );
+
+    // These are all well-formed packets, so the peer is not misbehaving and must not be kicked.
+    assert!(
+        tally.disconnected.is_empty(),
+        "a peer sending well-formed packets was dropped"
+    );
+
+    drop(server);
+    peer.join().expect("peer thread panicked");
+}
+
+/// The framing regression test.
+///
+/// The frozen destination slice also silently corrupted framing whenever two reads landed in a
+/// single readable event: the second read started writing at the same offset as the first and
+/// overwrote it. That is the likely cause of the long-standing, unreproducible "client stuck /
+/// disconnected under load" reports.
+#[test]
+fn several_packets_in_one_burst_arrive_intact_and_in_order() {
+    let (mut server, addr) = host();
+
+    let bodies: Vec<Vec<u8>> = (0..8u8)
+        .map(|i| vec![i.wrapping_mul(17); (i as usize + 1) * 64])
+        .collect();
+
+    let mut payload = Vec::new();
+    for (i, body) in bodies.iter().enumerate() {
+        payload.extend_from_slice(&packet_bytes(i as u8, body));
+    }
+
+    let peer = spawn_peer(addr, payload);
+
+    let mut tally = Tally::default();
+    assert!(
+        pump(&mut server, &mut tally, |t| t.packets.len() >= bodies.len()),
+        "only {} of {} packets arrived",
+        tally.packets.len(),
+        bodies.len()
+    );
+
+    assert_eq!(tally.packets.len(), bodies.len());
+    for (i, (_token, id, body)) in tally.packets.iter().enumerate() {
+        assert_eq!(*id, i as u8, "packet {} arrived out of order", i);
+        assert_eq!(body, &bodies[i], "packet {} body was corrupted", i);
+    }
+
+    assert_eq!(tally.received, bodies.len());
+
+    drop(server);
+    peer.join().expect("peer thread panicked");
+}
+
+/// The same framing guarantee, but for a burst several times larger than the buffer.
+///
+/// The server takes at most one bufferful per readable event, so this necessarily spans several
+/// ticks. That also proves the buffer-full path does not stall the connection.
+#[test]
+fn a_burst_larger_than_the_buffer_preserves_framing_across_ticks() {
+    let (mut server, addr) = host();
+
+    // ~48 KB, i.e. three times MAX_BUFFER_SIZE, in packets that do not divide evenly into it.
+    let count = 48;
+    let bodies: Vec<Vec<u8>> = (0..count)
+        .map(|i| vec![(i % 251) as u8; 700 + (i * 7) % 300])
+        .collect();
+
+    let mut payload = Vec::new();
+    for (i, body) in bodies.iter().enumerate() {
+        payload.extend_from_slice(&packet_bytes((i % 256) as u8, body));
+    }
+    assert!(payload.len() > 2 * MAX_BUFFER_SIZE);
+
+    let peer = spawn_peer(addr, payload);
+
+    let mut tally = Tally::default();
+    assert!(
+        pump(&mut server, &mut tally, |t| t.packets.len() >= count),
+        "only {} of {} packets arrived",
+        tally.packets.len(),
+        count
+    );
+
+    assert_eq!(tally.packets.len(), count);
+    for (i, (_token, id, body)) in tally.packets.iter().enumerate() {
+        assert_eq!(*id, (i % 256) as u8, "packet {} arrived out of order", i);
+        assert_eq!(body, &bodies[i], "packet {} body was corrupted", i);
+    }
+
+    assert!(
+        tally.disconnected.is_empty(),
+        "a peer sending well-formed packets was dropped"
+    );
+
+    drop(server);
+    peer.join().expect("peer thread panicked");
+}
+
+/// A packet split across several writes must still be reassembled correctly, and a partial
+/// header must never be completed with stale bytes from earlier traffic.
+#[test]
+fn a_packet_split_across_writes_is_reassembled() {
+    let (mut server, addr) = host();
+
+    let body: Vec<u8> = (0..500u32).map(|i| (i % 256) as u8).collect();
+    let expected = body.clone();
+    let wire = packet_bytes(0x5A, &body);
+
+    let peer = std::thread::spawn(move || {
+        let mut stream = TcpStream::connect(addr).expect("peer failed to connect");
+        stream
+            .set_nodelay(true)
+            .expect("peer failed to set nodelay");
+        stream
+            .set_read_timeout(Some(TIMEOUT))
+            .expect("peer failed to set a read timeout");
+
+        // Two bytes of the three byte header, so the third byte has genuinely not arrived.
+        stream.write_all(&wire[..2]).unwrap();
+        stream.flush().unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        // The rest of the header plus part of the body.
+        stream.write_all(&wire[2..100]).unwrap();
+        stream.flush().unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        // The remainder.
+        stream.write_all(&wire[100..]).unwrap();
+        stream.flush().unwrap();
+
+        let mut sink = [0u8; 1024];
+        let _ = stream.read(&mut sink);
+    });
+
+    let mut tally = Tally::default();
+    assert!(
+        pump(&mut server, &mut tally, |t| !t.packets.is_empty()),
+        "the split packet never arrived"
+    );
+
+    assert_eq!(tally.packets.len(), 1);
+    assert_eq!(tally.packets[0].1, 0x5A);
+    assert_eq!(tally.packets[0].2, expected);
+    assert!(
+        tally.disconnected.is_empty(),
+        "a peer sending a well-formed packet was dropped"
+    );
+
+    drop(server);
+    peer.join().expect("peer thread panicked");
+}
+
+/// A header declaring a body larger than `MAX_PACKET_BODY_SIZE` can never be satisfied, so the
+/// stream can never resynchronize. Prior to 0.2.3 the bytes were left in the buffer and
+/// re-parsed on every tick, logging a line each time: an unauthenticated log-flood vector.
+#[test]
+fn an_oversized_declared_body_drops_the_connection() {
+    let (mut server, addr) = host();
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&(MAX_PACKET_BODY_SIZE as u16).to_be_bytes());
+    payload.push(0x01);
+    payload.extend_from_slice(&[0xAB; 64]);
+
+    let peer = spawn_peer(addr, payload);
+
+    let mut tally = Tally::default();
+    assert!(
+        pump(&mut server, &mut tally, |t| !t.disconnected.is_empty()),
+        "the connection declaring an oversized body was not dropped"
+    );
+
+    assert_eq!(tally.connected.len(), 1);
+    assert_eq!(tally.disconnected, tally.connected);
+    assert!(tally.packets.is_empty(), "an oversized packet was accepted");
+    assert_eq!(server.num_connections(), 0);
+
+    peer.join().expect("peer thread panicked");
+}
+
+/// A peer that opens a packet header and then goes quiet must not be dropped, and must not
+/// cause the server to spin: it is simply an incomplete packet.
+#[test]
+fn a_peer_that_stops_mid_packet_is_left_alone() {
+    let (mut server, addr) = host();
+
+    // A legal header for a 4 KB body, followed by only 16 bytes of it.
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&4096u16.to_be_bytes());
+    payload.push(0x02);
+    payload.extend_from_slice(&[0x11; 16]);
+
+    let peer = spawn_peer(addr, payload);
+
+    let mut tally = Tally::default();
+    pump(&mut server, &mut tally, |t| !t.connected.is_empty());
+    pump_for(&mut server, &mut tally, Duration::from_millis(500));
+
+    assert_eq!(tally.connected.len(), 1);
+    assert!(
+        tally.disconnected.is_empty(),
+        "a peer with a merely incomplete packet was dropped"
+    );
+    assert!(
+        tally.packets.is_empty(),
+        "an incomplete packet was accepted"
+    );
+    assert_eq!(server.num_connections(), 1);
+
+    drop(server);
+    peer.join().expect("peer thread panicked");
+}
+
+/// A peer that closes the connection cleanly must still be reported as a disconnect. The
+/// buffer-full handling added in 0.2.3 must not swallow a genuine `Ok(0)`.
+#[test]
+fn a_clean_peer_shutdown_is_still_reported() {
+    let (mut server, addr) = host();
+
+    let wire = packet_bytes(0x09, &[1, 2, 3, 4]);
+    let peer = std::thread::spawn(move || {
+        let mut stream = TcpStream::connect(addr).expect("peer failed to connect");
+        stream.write_all(&wire).unwrap();
+        stream.flush().unwrap();
+        std::thread::sleep(Duration::from_millis(100));
+        drop(stream);
+    });
+
+    let mut tally = Tally::default();
+    assert!(
+        pump(&mut server, &mut tally, |t| !t.disconnected.is_empty()),
+        "a clean peer shutdown was never reported"
+    );
+
+    assert_eq!(tally.connected.len(), 1);
+    assert_eq!(tally.disconnected, tally.connected);
+    assert_eq!(
+        tally.packets.len(),
+        1,
+        "the packet sent before closing was lost"
+    );
+    assert_eq!(tally.packets[0].2, vec![1, 2, 3, 4]);
+    assert_eq!(server.num_connections(), 0);
+
+    peer.join().expect("peer thread panicked");
+}


### PR DESCRIPTION
Fixes #9.

Security fix for a remotely-triggerable memory-safety bug. An unauthenticated peer could corrupt the server's heap with a single `connect()` and a single ~64 KB `write()`, before any handshake or authentication. **Until this ships, the game port cannot safely be exposed to the internet.**

## The bug

`Server::tick()` computed the read destination slice **once, outside** the read loop, while `buffer.offset` accumulated **inside** it:

```rust
let buffer = &mut conn.buffer.data[conn.buffer.offset..];   // computed ONCE
loop {
    match conn.socket.read(buffer) {                        // same frozen slice every iteration
        Ok(read_bytes) => { conn.buffer.offset += read_bytes; }   // offset grows INSIDE the loop
        ...
    }
}
```

The slice length was frozen at `MAX_BUFFER_SIZE - offset_at_entry`, so four 16384-byte reads left `offset == 65536` on a 16384-byte array. `NetworkBuffer::drain` then derived a raw copy length from that offset and handed it to an unchecked `ptr::copy`:

```
ptr::copy(data + 3, data, 65533) over a 16384-byte array
```

`Connection` lives in a `HashMap<Token, Connection>`, so that is a ~48 KB out-of-bounds read **and write** across the heap, next to the vtable pointers of its `VecDeque<Box<dyn PacketBody>>`.

A **tiny** declared packet size was the trigger, not a large one: `packet_size == 3` makes the safe, bounds-checked slice on the preceding line `&data[3..3]`, an in-bounds empty slice that never fires. Nothing stopped the copy.

## Changes

**`src/server.rs`** — reads through a new shared helper that recomputes the destination slice on every iteration. A full buffer is never handed to `read()` as an empty slice, so it can no longer be misreported as a graceful `Ok(0)` disconnect. A buffer still full after every complete packet has been drained can never make progress, so it is treated as a protocol violation and the connection is dropped. Adds a `debug_assert!` plus a real runtime check that `offset` never exceeds `MAX_BUFFER_SIZE`.

**`src/client.rs`** — same buffer-full handling. The client already recomputed its slice inside the loop and never had the overflow, so its read shape is unchanged; it proves the correct pattern satisfies the borrow checker via disjoint field borrows, which is why the server-side hoisting was never necessary.

**`src/buffer.rs`** — `drain` no longer uses `unsafe`. It uses `copy_within`, and clamps a hostile `offset` and rejects an oversized `count` without relying on the caller. That closes the safe-code path to UB that existed regardless of the read loop:

```rust
let mut b = grubbnet::buffer::NetworkBuffer::new();
b.offset = usize::MAX;
b.drain(0);            // safe fn -> UB in 0.2.2
```

Adds `try_drain`, which reports an error instead of panicking. Both call sites in the crate use it, since a panic here would still remotely kill a single-process server. The panicking `drain` is kept for API compatibility. The fields stay `pub` — making them private would be a breaking change requiring 0.3.0, so `drain` is made defensive instead.

**`src/packet.rs`** — a header is no longer parsed from bytes that have not arrived. Fewer than `PACKET_HEADER_SIZE` buffered bytes now yields `Incomplete` before any byte is read, rather than completing the header with stale bytes from earlier traffic. Malformed headers no longer log, closing an attacker-controlled log-flood vector; the caller decides, and drops the connection.

The crate contains no other `unsafe`, and no other place where a length derived from network input indexes a fixed-size array. `crypto.rs` is `cargo fmt` only.

## Verification

Unit tests for `drain` cover `count == 0`, `count == offset`, `count > offset`, and the adversarial `offset > MAX_BUFFER_SIZE` case. Read-loop tests run against a `MockReader` mirroring the existing `MockWriter`, returning `MAX_BUFFER_SIZE` bytes several times then `WouldBlock`, asserting `offset` never exceeds `MAX_BUFFER_SIZE`. Integration tests host a real `Server` on `127.0.0.1:0` and drive it with a plain `std::net::TcpStream`.

**These are genuine regression tests.** Run against `9661f76` (this crate's `main`, byte-identical to published 0.2.2), with only `local_addr` added so they compile:

| Test | 0.2.2 | This PR |
|---|---|---|
| 64 KB burst, header `00 00 00` | FAILED — connection never dropped | ok |
| 64 KB of empty packets | **SEGFAULT, `STATUS_ACCESS_VIOLATION (0xc0000005)`** | ok |
| Burst larger than the buffer | FAILED — framing corrupted | ok |
| Oversized declared body | FAILED — log flood, never dropped | ok |

The segfault is the out-of-bounds `ptr::copy` actually executing.

- `cargo test --all-features`: **41 unit + 8 integration tests pass.**
- `cargo +nightly miri test --lib`: **all 41 pass, no UB reported.**
- `cargo fmt` clean.

The framing test also guards a real past symptom: the frozen slice silently corrupted framing whenever two reads landed in one readable event, because the second overwrote the first. That is the likely cause of the long-standing, unreproducible "client stuck / disconnected under load" reports.

## Compatibility — drop-in for 0.2.3

**No new `ServerEvent` variant.** Protocol violations are reported through the existing `ClientDisconnected(Token)` path, so the Antorum consumer's `_ => error!("Unhandled ServerEvent!")` catch-all never fires and there is no log spam. Consumers can bump the version with no code change.

No public item was removed and no existing signature changed. Additions only: `Server::local_addr()`, `#[derive(Debug)]` on `PacketHeader`, `impl Default for NetworkBuffer`, and the new `NetworkBuffer` methods. The new helpers (`read_into_buffer`, `ReadOutcome`, `parse_packet_header`, `HeaderParse`) are `pub(crate)`.

`MAX_BUFFER_SIZE`, `MAX_PACKET_BODY_SIZE` and the wire format are untouched. No new runtime dependencies.

### Behavioural changes to be aware of

1. A connection is now **dropped** when it sends a header declaring a body larger than `MAX_PACKET_BODY_SIZE`. In 0.2.2 those bytes stayed in the buffer and were re-parsed and re-logged on every tick, forever.
2. A connection is now **dropped** when its buffer is completely full and contains no complete packet. Unreachable for a well-behaved peer, since the buffer has ~2x the headroom of the largest legal packet.
3. A full buffer is **no longer reported as a graceful disconnect**. It is handled explicitly, and a genuine peer shutdown is still reported as before.
4. `deserialize_packet_header` now returns `Err(Error::InvalidData)` when fewer than 3 bytes are buffered, instead of parsing stale bytes. It no longer prints to stderr.
5. At most one bufferful is read per connection per readable event, so one firehose peer cannot starve the others. Leftover bytes are picked up on the next tick, verified by the >16 KB framing test.
