### PR TITLE
[fixes #5] Update dependencies (v0.3.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "grubbnet"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Declan Hopkins <ratwizarddev@gmail.com>"]
 edition = "2018"
+rust-version = "1.85"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/dooskington/grubbnet"
@@ -14,14 +15,14 @@ name = "grubbnet"
 crate-type = ["rlib"]
 
 [dependencies]
-mio = { version = "0.8", features = ["os-poll", "net"] }
+mio = { version = "1.0", features = ["os-poll", "net"] }
 byteorder = "1.5.0"
-derive_more = "0.99.17"
-openssl = { version = "0.10.75", optional = true }
-bcrypt = { version = "0.19", optional = true }
+derive_more = { version = "2.0", features = ["display", "from"] }
+openssl = { version = "0.10.81", optional = true }
+bcrypt = { version = "0.19.3", optional = true }
 
 [dev-dependencies]
-wincode = { version = "0.5.5", features = ["derive"] }
+wincode = { version = "0.6.0", features = ["derive"] }
 
 [features]
 crypto = ["openssl", "bcrypt"]

--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ panicking.
  Add this to your `Cargo.toml`:
  ```toml
  [dependencies]
- grubbnet = "0.2"
+ grubbnet = "0.3"
  ```
+
+Grubbnet requires Rust 1.85 or newer.
 
 Hosting a barebones server that sends a simple packet:
 ```rust
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(wincode::SchemaWrite, wincode::SchemaRead, Clone)]
 pub struct MessagePacket { pub msg: String }
 
 impl PacketBody for MessagePacket {
@@ -69,16 +71,13 @@ impl PacketBody for MessagePacket {
         Box::new((*self).clone())
     }
 
-    fn serialize(&self) -> Vec<u8> {
+    fn serialize(&self) -> Result<Vec<u8>> {
         // Define your own serialization here.
-        // I like to use serde & bincode.
-        bincode::config()
-            .big_endian()
-            .serialize::<Self>(&self)
-            .unwrap()
+        // The examples use wincode, but anything that produces bytes will do.
+        wincode::serialize(self).map_err(|_e| grubbnet::Error::InvalidData)
     }
 
-    fn deserialize(_data: &[u8]) -> Self {
+    fn deserialize(_data: &[u8]) -> Result<Self> {
         panic!("Attempted to deserialize a server-only packet!");
     }
 


### PR DESCRIPTION
Closes #5.

Brings every dependency up to its latest release.

## Dependencies

| Crate | From | To | Notes |
| --- | --- | --- | --- |
| `mio` | 0.8 | 1.0 | major bump, no API changes needed here |
| `derive_more` | 0.99.17 | 2.0 | features are now opt-in, so `display` and `from` are requested explicitly |
| `openssl` | 0.10.75 | 0.10.81 | `crypto` feature only |
| `bcrypt` | 0.19 | 0.19.3 | `crypto` feature only |
| `wincode` | 0.5.5 | 0.6.0 | dev-dependency, used by the examples |

`byteorder` was already on the latest release (1.5.0).

## Why a minor bump and not a patch

mio shows up in the public API - `Token` is re-exported from the crate root and
`send_bytes` takes a `mio::net::TcpStream` - so a mio major bump is breaking for
any downstream crate that shares those types with grubbnet. Under cargo's semver
rules for `0.x`, that makes this `0.3.0` rather than `0.2.4`.

## derive_more 2.x

The 1.0 release made derives opt-in per feature and reworked `Display`, so this
was the one bump with a real chance of silently changing behaviour: `Error` is
what users see when something goes wrong.

I diffed the rendered output across both versions and it is identical - unit
variants still render as the variant name, and `Io` still forwards to the inner
error:

```
Io           => connection reset
FailedToSend => FailedToSendBytes
InvalidData  => InvalidData
NotFound     => ConnectionNotFound
FailedToReg  => FailedToRegisterForEvents
```

## MSRV

The new dependency set raises the minimum toolchain to **1.85**, now declared via
`rust-version` and documented in the README.

Worth noting where that number comes from: it is not `derive_more`'s own declared
MSRV (1.81), but a transitive dep of it - `convert_case` -> `unicode-segmentation`
1.13.3 - which requires 1.85. That is invisible from the manifest, so I verified
it by building against real toolchains rather than reading declared values: 1.81
fails to resolve, 1.85 builds both the default and `crypto` feature sets.

## README

The packet example still used `bincode` and the pre-0.2.0 `PacketBody` signatures
(`-> Vec<u8>` / `-> Self` instead of the `Result` versions). bincode was dropped
back in v0.2.2 when the examples moved to wincode, but the README was never
updated to match, so the snippet as written would not compile. It now mirrors
`examples/simple_server.rs`.

## Verification

- `cargo test --all-targets --all-features` - 49 passed, 0 failed
- `cargo build --lib` and `--lib --features crypto` on 1.85.0 - both clean
- `cargo fmt --check` - clean
- No new warnings (the one `unreachable_code` warning in `simple_server` is pre-existing)
- Ran `simple_server` + `simple_client` end to end, since the mio major bump
  touches the non-blocking connect path that the integration tests do not cover.
  Full round trip works: connect, five ping/pong exchanges, then the server kicks
  the client and both sides observe the disconnect.

Not merged, as requested.
