### PR TITLE
[fixes #14] Bound the serialized packet body (v0.3.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grubbnet"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Declan Hopkins <ratwizarddev@gmail.com>"]
 edition = "2018"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ a complete packet can be pulled off the front of it. A packet body may be up to 
 (`MAX_PACKET_BODY_SIZE` is 8192, and the check is exclusive), so the buffer always has roughly
 twice the headroom of the largest legal packet.
 
+The same bound is enforced on the way out: `serialize_packet` returns `Error::PacketTooLarge`
+rather than emitting a packet the receiver is obliged to reject. This matters because the body
+length is a 16 bit field, so a body of 65536 or more would otherwise wrap it and leave the peer
+parsing the body as headers, desynchronising the connection for good. A body that is too large
+is a bug in the sending application, so it is reported to that application instead of being put
+on the wire.
+
 Packets are framed, not message-oriented, so none of this is affected by how a peer chooses to
 split its writes. A packet spread across several `write` calls is reassembled, and several
 packets delivered in a single `write` burst all arrive intact and in order, however the bytes

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,11 @@ pub enum Error {
     InvalidData,
     ConnectionNotFound,
 
+    /// A packet body was too large to describe in a header. Always a bug in the sending
+    /// application rather than something a peer did.
+    #[display("packet body of {_0} bytes reaches or exceeds the {_1} byte limit")]
+    PacketTooLarge(usize, usize),
+
     #[doc(hidden)]
     __Nonexhaustive,
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -45,9 +45,19 @@ pub struct Packet {
     pub body: Vec<u8>,
 }
 
+/// Serializes `body` into a complete packet, header included.
+///
+/// Returns [`Error::PacketTooLarge`] if the body reaches [`MAX_PACKET_BODY_SIZE`], mirroring
+/// the check [`parse_packet_header`] applies on the way in. Without it a body over 65535 wraps
+/// the 16 bit length field, and the peer reads the middle of the body as the next header and
+/// desynchronises for the rest of the connection.
 pub fn serialize_packet(body: Box<dyn PacketBody>) -> Result<Vec<u8>, Error> {
     // Serialize the packet body first so we know the size
     let mut body_data: Vec<u8> = body.serialize()?;
+
+    if body_data.len() >= MAX_PACKET_BODY_SIZE {
+        return Err(Error::PacketTooLarge(body_data.len(), MAX_PACKET_BODY_SIZE));
+    }
 
     // Create payload and write header (body size and id)
     let mut data: Vec<u8> = Vec::new();
@@ -131,6 +141,30 @@ pub fn deserialize_packet_header(buffer: &mut NetworkBuffer) -> Result<PacketHea
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct Body(Vec<u8>);
+
+    impl PacketBody for Body {
+        fn box_clone(&self) -> Box<dyn PacketBody> {
+            Box::new(Body(self.0.clone()))
+        }
+
+        fn serialize(&self) -> Result<Vec<u8>, Error> {
+            Ok(self.0.clone())
+        }
+
+        fn deserialize(data: &[u8]) -> Result<Self, Error> {
+            Ok(Body(data.to_vec()))
+        }
+
+        fn id(&self) -> u8 {
+            0x2A
+        }
+    }
+
+    fn serialize_body_of(size: usize) -> Result<Vec<u8>, Error> {
+        serialize_packet(Box::new(Body(vec![0u8; size])))
+    }
 
     fn buffer_with(bytes: &[u8]) -> NetworkBuffer {
         let mut buffer = NetworkBuffer::new();
@@ -251,26 +285,6 @@ mod tests {
 
     #[test]
     fn a_serialized_packet_round_trips_through_the_header_parser() {
-        struct Body(Vec<u8>);
-
-        impl PacketBody for Body {
-            fn box_clone(&self) -> Box<dyn PacketBody> {
-                Box::new(Body(self.0.clone()))
-            }
-
-            fn serialize(&self) -> Result<Vec<u8>, Error> {
-                Ok(self.0.clone())
-            }
-
-            fn deserialize(data: &[u8]) -> Result<Self, Error> {
-                Ok(Body(data.to_vec()))
-            }
-
-            fn id(&self) -> u8 {
-                0x2A
-            }
-        }
-
         let data = serialize_packet(Box::new(Body(vec![1, 2, 3, 4, 5]))).unwrap();
         assert_eq!(data.len(), PACKET_HEADER_SIZE + 5);
 
@@ -282,5 +296,49 @@ mod tests {
             }
             other => panic!("expected a parsed header, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn the_largest_legal_body_is_serialized() {
+        let data = serialize_body_of(MAX_PACKET_BODY_SIZE - 1).expect("body is within the limit");
+
+        assert_eq!(data.len(), MAX_PACKET_SIZE - 1);
+
+        let buffer = buffer_with(&data);
+        match parse_packet_header(&buffer) {
+            HeaderParse::Parsed(header) => {
+                assert_eq!(header.size as usize, MAX_PACKET_BODY_SIZE - 1)
+            }
+            other => panic!("expected a parsed header, got {:?}", other),
+        }
+    }
+
+    /// The read path rejects a header at the limit, so the write path must not produce one.
+    #[test]
+    fn a_body_at_the_size_limit_is_refused() {
+        assert!(matches!(
+            serialize_body_of(MAX_PACKET_BODY_SIZE),
+            Err(Error::PacketTooLarge(size, limit))
+                if size == MAX_PACKET_BODY_SIZE && limit == MAX_PACKET_BODY_SIZE
+        ));
+    }
+
+    /// A body of 65536 casts to a length of 0, which framed the packet as empty and left the
+    /// body to be parsed as headers, desynchronising the connection permanently.
+    #[test]
+    fn a_body_that_would_wrap_the_length_field_is_refused() {
+        let wrapping_size = u16::MAX as usize + 1;
+
+        assert!(matches!(
+            serialize_body_of(wrapping_size),
+            Err(Error::PacketTooLarge(size, _)) if size == wrapping_size
+        ));
+    }
+
+    #[test]
+    fn an_empty_body_is_serialized() {
+        let data = serialize_body_of(0).expect("an empty body is legal");
+
+        assert_eq!(data.len(), PACKET_HEADER_SIZE);
     }
 }


### PR DESCRIPTION
`serialize_packet` wrote the body length with an unchecked cast and never checked the body against `MAX_PACKET_BODY_SIZE`, so it would happily build packets no peer can accept.

A body between 8192 and 65535 went out on the wire and was rejected at the far end by `parse_packet_header` as a protocol violation, dropping the connection — with nothing reported to the sender, which had been handed an `Ok`. A body of 65536 or more wrapped the 16 bit length field: `65536 as u16` is `0`, so the header described a length unrelated to the bytes that followed, the peer consumed the wrong byte count, and every subsequent read parsed the middle of a body as a header. Framing has no delimiter or magic number, so the connection could never resynchronise.

That second case is not theoretical. I hit it in a game server built on grubbnet: under load a region's state serialized past 64 KiB, and every client in that region started decoding garbage — packet ids that were never sent, zero length bodies, world state frozen at the moment of the desync. It presents as data corruption a long way from the actual cause.

## What changed

`serialize_packet` now applies the same bound `parse_packet_header` already applies, so the library can no longer emit a packet it would refuse to read. The failure is reported through a new `Error::PacketTooLarge(size, limit)` variant, which carries the offending size and reads as the application bug it is, rather than being flattened into `InvalidData` alongside genuinely malformed peer input.

I kept the limit at `MAX_PACKET_BODY_SIZE` rather than the 65535 the header could technically describe. `MAX_BUFFER_SIZE` is deliberately about twice `MAX_PACKET_SIZE`, so a larger body could not be buffered by a receiver even if the header could describe it — 8192 is structural, not arbitrary. Raising it is a separate discussion.

## Notes for review

- **This is a behaviour change for anyone currently sending bodies of 8192 or more.** Those packets were already unreadable by a grubbnet peer, but a more permissive non-grubbnet implementation of the protocol may have been accepting them. Such a sender will now get an error instead of a silently-doomed packet, which is the point, but it is worth knowing before upgrading.
- The `Body` test helper was hoisted from inside a single test to the `tests` module so the new size tests could reuse it. No behaviour change to the existing test.
- Four new tests: the largest legal body serializes and round-trips through the header parser, a body exactly at the limit is refused, a body that would wrap the length field is refused, and an empty body still works.
- 45 unit tests and 8 integration tests pass; `cargo fmt --check` is clean and clippy reports no new warnings (7 before and after, all from the pre-existing `__Nonexhaustive` variant).

Version bumped to 0.3.1.

Closes #14.
